### PR TITLE
Integrate AccessKit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ name = "render_egui_to_image"
 required-features = ["picking", "render", "bevy/bevy_gizmos"]
 
 [dependencies]
-egui = { version = "0.31", default-features = false }
+egui = { version = "0.31", default-features = false, features = ["accesskit"] }
+bevy_a11y = "0.15.0"
 bevy_app = "0.15.0"
 bevy_derive = "0.15.0"
 bevy_ecs = "0.15.0"
@@ -105,6 +106,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 version-sync = "0.9.4"
 bevy = { version = "0.15.0", default-features = false, features = [
+    "accesskit_unix",
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",


### PR DESCRIPTION
This integrates Bevy's AccessKit setup with egui's AccessKit integration so egui UIs are accessible.

I haven't been able to test this on Linux, where it may not work since accesskit integration is feature-gated there. In theory it should just pull in dependencies and more or less be a no-op since an access technology will never request accessibility, but I can't say for sure and would appreciate help testing.

Thanks!