### PR TITLE
fix dead links to old 'mvlabat' user to new 'vladbat00' user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to Bevy 0.15 ([#309](https://github.com/mvlabat/bevy_egui/pull/309) by @Vrixyz).
+- Update to Bevy 0.15 ([#309](https://github.com/vladbat00/bevy_egui/pull/309) by @Vrixyz).
 
 ### Fixed
 
@@ -25,20 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Depend on bevy subcrates for compile time improvement ([#319](https://github.com/mvlabat/bevy_egui/pull/319) by @aevyrie).
+- Depend on bevy subcrates for compile time improvement ([#319](https://github.com/vladbat00/bevy_egui/pull/319) by @aevyrie).
 
 ## [0.30.0] - 4-Oct-2024
 
 ### Added
 
-- `prepare_render` step support for `EguiBevyPaintCallbackImpl` ([#306](https://github.com/mvlabat/bevy_egui/pull/306) by @PPakalns).
-- Mobile virtual keyboard support in web ([#279](https://github.com/mvlabat/bevy_egui/pull/279) by @v-kat).
+- `prepare_render` step support for `EguiBevyPaintCallbackImpl` ([#306](https://github.com/vladbat00/bevy_egui/pull/306) by @PPakalns).
+- Mobile virtual keyboard support in web ([#279](https://github.com/vladbat00/bevy_egui/pull/279) by @v-kat).
   - Requires `Window::prevent_default_event_handling` being set to `false`.
-- IME support (#[204](https://github.com/mvlabat/bevy_egui/pull/204) by @EReeves).
+- IME support (#[204](https://github.com/vladbat00/bevy_egui/pull/204) by @EReeves).
 
 ### Changed
 
-- Update Egui to 0.29 ([#313](https://github.com/mvlabat/bevy_egui/pull/313) by @PPakalns).
+- Update Egui to 0.29 ([#313](https://github.com/vladbat00/bevy_egui/pull/313) by @PPakalns).
 
 ### Additional notes on breaking changes
 
@@ -49,32 +49,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial worldspace UI support ([#304](https://github.com/mvlabat/bevy_egui/pull/304) by @TheButlah, @Schmarni-Dev).
-- Paint callback support ([#303](https://github.com/mvlabat/bevy_egui/pull/303) by @PPakalns).
+- Initial worldspace UI support ([#304](https://github.com/vladbat00/bevy_egui/pull/304) by @TheButlah, @Schmarni-Dev).
+- Paint callback support ([#303](https://github.com/vladbat00/bevy_egui/pull/303) by @PPakalns).
 
 ### Changed
 
-- Adapt to `web-sys` clipboard api change ([#301](https://github.com/mvlabat/bevy_egui/pull/301) by @no-materials).
+- Adapt to `web-sys` clipboard api change ([#301](https://github.com/vladbat00/bevy_egui/pull/301) by @no-materials).
 
 ### Fixed
 
-- Clear modifier state when focus is lost ([#298](https://github.com/mvlabat/bevy_egui/pull/298) by @SludgePhD).
-- Fix redraws ([#293](https://github.com/mvlabat/bevy_egui/pull/293)).
+- Clear modifier state when focus is lost ([#298](https://github.com/vladbat00/bevy_egui/pull/298) by @SludgePhD).
+- Fix redraws ([#293](https://github.com/vladbat00/bevy_egui/pull/293)).
 
 ## [0.28.0] - 6-Jul-2024
 
 ### Changed
 
-- Update Bevy to 0.14 ([#284](https://github.com/mvlabat/bevy_egui/pull/284) by @Friz64).
-- Update Egui to 0.28 ([#290](https://github.com/mvlabat/bevy_egui/pull/290) by @Swoorup).
+- Update Bevy to 0.14 ([#284](https://github.com/vladbat00/bevy_egui/pull/284) by @Friz64).
+- Update Egui to 0.28 ([#290](https://github.com/vladbat00/bevy_egui/pull/290) by @Swoorup).
 - Update webbrowser to 1.0.1
 
 ## [0.27.1] - 2-Jun-2024
 
 ### Changed
 
-- Request Redraw only if really needed ([#278](https://github.com/mvlabat/bevy_egui/pull/278) by @Maximetinu).
-- Fix light in the `render_to_image_wideget` example ([#282](https://github.com/mvlabat/bevy_egui/pull/282) by @rlidwka).
+- Request Redraw only if really needed ([#278](https://github.com/vladbat00/bevy_egui/pull/278) by @Maximetinu).
+- Fix light in the `render_to_image_wideget` example ([#282](https://github.com/vladbat00/bevy_egui/pull/282) by @rlidwka).
 
 ## [0.27.0] - 18-Apr-2024
 
@@ -84,12 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update Egui to 0.27 ([#271](https://github.com/mvlabat/bevy_egui/pull/271) by @jakobhellermann).
-- Improve compilation errors when missing `web_sys_unstable_apis` ([#270](https://github.com/mvlabat/bevy_egui/pull/270) by @Vrixyz).
+- Update Egui to 0.27 ([#271](https://github.com/vladbat00/bevy_egui/pull/271) by @jakobhellermann).
+- Improve compilation errors when missing `web_sys_unstable_apis` ([#270](https://github.com/vladbat00/bevy_egui/pull/270) by @Vrixyz).
 
 ### Fixed
 
-- Rework reading window ids for events (fixes edge-cases with ignoring events, [#273](https://github.com/mvlabat/bevy_egui/pull/273)).
+- Rework reading window ids for events (fixes edge-cases with ignoring events, [#273](https://github.com/vladbat00/bevy_egui/pull/273)).
 
 ### Removed
 
@@ -99,132 +99,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add web clipboard support ([#267](https://github.com/mvlabat/bevy_egui/pull/267), [#178](https://github.com/mvlabat/bevy_egui/pull/178) by @Vrixyz).
+- Add web clipboard support ([#267](https://github.com/vladbat00/bevy_egui/pull/267), [#178](https://github.com/vladbat00/bevy_egui/pull/178) by @Vrixyz).
 
 ### Fixed
 
-- Respect `egui::TextureOptions` for managed textures ([#264](https://github.com/mvlabat/bevy_egui/pull/264) by @TheRawMeatball).
-- Fix keybind modifiers ([#265](https://github.com/mvlabat/bevy_egui/pull/265) by @eero-lehtinen).
+- Respect `egui::TextureOptions` for managed textures ([#264](https://github.com/vladbat00/bevy_egui/pull/264) by @TheRawMeatball).
+- Fix keybind modifiers ([#265](https://github.com/vladbat00/bevy_egui/pull/265) by @eero-lehtinen).
 
 ## [0.25.0] - 19-Feb-2024
 
 ### Added
 
-- Add `render` feature which can be disabled for applications with a custom renderer ([#240](https://github.com/mvlabat/bevy_egui/pull/240) by @BeastLe9enD).
+- Add `render` feature which can be disabled for applications with a custom renderer ([#240](https://github.com/vladbat00/bevy_egui/pull/240) by @BeastLe9enD).
 
 ### Changed
 
-- Update Bevy to 0.13 ([#236](https://github.com/mvlabat/bevy_egui/pull/236) by @eri).
+- Update Bevy to 0.13 ([#236](https://github.com/vladbat00/bevy_egui/pull/236) by @eri).
 - Update Egui to 0.26.
 
 ### Fixed
 
-- Retrieve user agent for better platform detection on WASM ([#256](https://github.com/mvlabat/bevy_egui/pull/256) by @Vrixyz).
-- Remove unused `once_cell` dev-dependency ([#258](https://github.com/mvlabat/bevy_egui/pull/258) by @frewsxcv).
-- Make fields inside `WindowSize` pub ([#251](https://github.com/mvlabat/bevy_egui/pull/251) by @BeastLe9enD).
-- Fix requested repaints not causing Bevy to redraw ([#240](https://github.com/mvlabat/bevy_egui/pull/240) by @andriyDev).
-- Fix build on Android with default features ([#241](https://github.com/mvlabat/bevy_egui/pull/241) by @Hellzbellz123).
+- Retrieve user agent for better platform detection on WASM ([#256](https://github.com/vladbat00/bevy_egui/pull/256) by @Vrixyz).
+- Remove unused `once_cell` dev-dependency ([#258](https://github.com/vladbat00/bevy_egui/pull/258) by @frewsxcv).
+- Make fields inside `WindowSize` pub ([#251](https://github.com/vladbat00/bevy_egui/pull/251) by @BeastLe9enD).
+- Fix requested repaints not causing Bevy to redraw ([#240](https://github.com/vladbat00/bevy_egui/pull/240) by @andriyDev).
+- Fix build on Android with default features ([#241](https://github.com/vladbat00/bevy_egui/pull/241) by @Hellzbellz123).
 
 ## [0.24.0] - 11-Dec-2023
 
 ### Changed
 
-- Update Egui to 0.24 ([#234](https://github.com/mvlabat/bevy_egui/pull/234) by @naomijub, @frewsxcv).
+- Update Egui to 0.24 ([#234](https://github.com/vladbat00/bevy_egui/pull/234) by @naomijub, @frewsxcv).
 
 ### Fixed
 
-- Handle giving time input to egui correctly ([#226](https://github.com/mvlabat/bevy_egui/pull/226) by @TheRawMeatball).
+- Handle giving time input to egui correctly ([#226](https://github.com/vladbat00/bevy_egui/pull/226) by @TheRawMeatball).
 
 ## [0.23.0] - 5-Nov-2023
 
 ### Changed
 
-- Update Bevy to 0.12 ([#221](https://github.com/mvlabat/bevy_egui/pull/221) by @raffaeleragni).
+- Update Bevy to 0.12 ([#221](https://github.com/vladbat00/bevy_egui/pull/221) by @raffaeleragni).
 
 ### Fixed
 
-- Fix color attachments in WASM (WebGPU) ([#220](https://github.com/mvlabat/bevy_egui/pull/220) by @seabassjh, @frewsxcv).
+- Fix color attachments in WASM (WebGPU) ([#220](https://github.com/vladbat00/bevy_egui/pull/220) by @seabassjh, @frewsxcv).
 
 ## [0.22.0] - 7-Oct-2023
 
 ### Added
 
-- Add `#[derive(Reflect)]` ([#195](https://github.com/mvlabat/bevy_egui/pull/195) by @SludgePhD).
+- Add `#[derive(Reflect)]` ([#195](https://github.com/vladbat00/bevy_egui/pull/195) by @SludgePhD).
 
 ### Changed
 
-- Update Egui to 0.23 ([#217](https://github.com/mvlabat/bevy_egui/pull/217) by @zicklag).
-- Refactor components and resources extraction ([#210](https://github.com/mvlabat/bevy_egui/pull/210), [#211](https://github.com/mvlabat/bevy_egui/pull/211) by @TheButlah).
+- Update Egui to 0.23 ([#217](https://github.com/vladbat00/bevy_egui/pull/217) by @zicklag).
+- Refactor components and resources extraction ([#210](https://github.com/vladbat00/bevy_egui/pull/210), [#211](https://github.com/vladbat00/bevy_egui/pull/211) by @TheButlah).
 
 ## [0.21.0] - 10-Jul-2023
 
 ### Added
 
-- Add touch events support ([#180](https://github.com/mvlabat/bevy_egui/pull/180) by @oscrim).
+- Add touch events support ([#180](https://github.com/vladbat00/bevy_egui/pull/180) by @oscrim).
 
 ### Changed
 
-- Update Bevy to 0.11 ([#188](https://github.com/mvlabat/bevy_egui/pull/188) by @Vrixyz).
-- Update Egui to 0.22 ([#184](https://github.com/mvlabat/bevy_egui/pull/184)).
-- Move sampler descriptor into `EguiSettings` ([#179](https://github.com/mvlabat/bevy_egui/pull/179) by @GlummixX).
-- Update GitHub Actions CI ([#183](https://github.com/mvlabat/bevy_egui/pull/183) by @striezel).
+- Update Bevy to 0.11 ([#188](https://github.com/vladbat00/bevy_egui/pull/188) by @Vrixyz).
+- Update Egui to 0.22 ([#184](https://github.com/vladbat00/bevy_egui/pull/184)).
+- Move sampler descriptor into `EguiSettings` ([#179](https://github.com/vladbat00/bevy_egui/pull/179) by @GlummixX).
+- Update GitHub Actions CI ([#183](https://github.com/vladbat00/bevy_egui/pull/183) by @striezel).
 
 ## [0.20.3] - 21-Apr-2023
 
 ### Fixed
 
-- Accept NumpadEnter as Enter ([#171](https://github.com/mvlabat/bevy_egui/pull/171) by @dimvoly).
+- Accept NumpadEnter as Enter ([#171](https://github.com/vladbat00/bevy_egui/pull/171) by @dimvoly).
 
 ## [0.20.2] - 27-Mar-2023
 
 ### Changed
 
-- Move `bevy_core_pipeline` to dev-dependencies ([#166](https://github.com/mvlabat/bevy_egui/pull/166) by @jakobhellermann).
+- Move `bevy_core_pipeline` to dev-dependencies ([#166](https://github.com/vladbat00/bevy_egui/pull/166) by @jakobhellermann).
 
 ### Fixed
 
-- Fix incorrect bounds check for set_scissor_rect ([#167](https://github.com/mvlabat/bevy_egui/pull/167) by @Gorialis).
+- Fix incorrect bounds check for set_scissor_rect ([#167](https://github.com/vladbat00/bevy_egui/pull/167) by @Gorialis).
 - Fix panic messages for uninitialised contexts.
 
 ## [0.20.1] - 12-Mar-2023
 
 ### Fixed
 
-- Fix recreation of `EguiContext` on startup ([#162](https://github.com/mvlabat/bevy_egui/pull/162) by @encounter).
-- Set image sampler address modes to `ClampToEdge` ([#158](https://github.com/mvlabat/bevy_egui/pull/158) by @galop1n).
+- Fix recreation of `EguiContext` on startup ([#162](https://github.com/vladbat00/bevy_egui/pull/162) by @encounter).
+- Set image sampler address modes to `ClampToEdge` ([#158](https://github.com/vladbat00/bevy_egui/pull/158) by @galop1n).
 
 ## [0.20.0] - 8-Mar-2023
 
 ### Added
 
-- Add `altgr` support for Windows ([#149](https://github.com/mvlabat/bevy_egui/pull/149) by @Vrixyz).
-- Add `serde` feature ([#154](https://github.com/mvlabat/bevy_egui/pull/154) by @AlanRace).
+- Add `altgr` support for Windows ([#149](https://github.com/vladbat00/bevy_egui/pull/149) by @Vrixyz).
+- Add `serde` feature ([#154](https://github.com/vladbat00/bevy_egui/pull/154) by @AlanRace).
 
 ### Changed
 
-- Update Bevy to 0.10 ([#159](https://github.com/mvlabat/bevy_egui/pull/159), thanks to @DGriffin91).
-- Update Egui to 0.21 ([#152](https://github.com/mvlabat/bevy_egui/pull/152) by @paul-hansen).
-- Implement better multi-window support ([#147](https://github.com/mvlabat/bevy_egui/pull/147) by @TheRawMeatball).
+- Update Bevy to 0.10 ([#159](https://github.com/vladbat00/bevy_egui/pull/159), thanks to @DGriffin91).
+- Update Egui to 0.21 ([#152](https://github.com/vladbat00/bevy_egui/pull/152) by @paul-hansen).
+- Implement better multi-window support ([#147](https://github.com/vladbat00/bevy_egui/pull/147) by @TheRawMeatball).
 
 ### Fixed
 
-- Pass raw Bevy time to Egui to fix UI animations ([#155](https://github.com/mvlabat/bevy_egui/pull/155) by @jakobhellermann).
+- Pass raw Bevy time to Egui to fix UI animations ([#155](https://github.com/vladbat00/bevy_egui/pull/155) by @jakobhellermann).
 
 ## [0.19.0] - 15-Jan-2023
 
 ### Changed
 
-- Update the `arboard` dependency ([#142](https://github.com/mvlabat/bevy_egui/pull/142) by @jakobhellermann).
+- Update the `arboard` dependency ([#142](https://github.com/vladbat00/bevy_egui/pull/142) by @jakobhellermann).
 
 ### Fixed
 
-- Fix panics due to missing swapchain textures ([#141](https://github.com/mvlabat/bevy_egui/pull/141) by @connerebbinghaus).
+- Fix panics due to missing swapchain textures ([#141](https://github.com/vladbat00/bevy_egui/pull/141) by @connerebbinghaus).
 
 ## [0.18.0] - 11-Dec-2022
 
 ### Changed
 
-- Update Egui to 0.20 ([#139](https://github.com/mvlabat/bevy_egui/pull/139) by @no-materials).
+- Update Egui to 0.20 ([#139](https://github.com/vladbat00/bevy_egui/pull/139) by @no-materials).
 
 ## [0.17.1] - 14-Nov-2022
 
@@ -236,17 +236,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to Bevy 0.9 ([#127](https://github.com/mvlabat/bevy_egui/pull/127), [#133](https://github.com/mvlabat/bevy_egui/pull/133), thanks to @terhechte and @jakobhellermann).
+- Update to Bevy 0.9 ([#127](https://github.com/vladbat00/bevy_egui/pull/127), [#133](https://github.com/vladbat00/bevy_egui/pull/133), thanks to @terhechte and @jakobhellermann).
 
 ### Fixed
 
-- Fix window resizing on Windows ([#128](https://github.com/mvlabat/bevy_egui/pull/128) by @chronicl). 
+- Fix window resizing on Windows ([#128](https://github.com/vladbat00/bevy_egui/pull/128) by @chronicl). 
 
 ## [0.16.1] - 18-Sep-2022
 
 ### Fixed
 
-- Fix releasing buttons outside a window ([#123](https://github.com/mvlabat/bevy_egui/pull/123), thanks to @TheRawMeatball for flagging the issue in [#121](https://github.com/mvlabat/bevy_egui/pull/121)).
+- Fix releasing buttons outside a window ([#123](https://github.com/vladbat00/bevy_egui/pull/123), thanks to @TheRawMeatball for flagging the issue in [#121](https://github.com/vladbat00/bevy_egui/pull/121)).
 
 ## [0.16.0] - 24-Aug-2022
 
@@ -264,19 +264,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a feature that can be disabled to replace default Egui fonts ([#110](https://github.com/mvlabat/bevy_egui/pull/110) by @iTitus).
+- Add a feature that can be disabled to replace default Egui fonts ([#110](https://github.com/vladbat00/bevy_egui/pull/110) by @iTitus).
 
 ### Changed
  
-- Update Bevy to 0.8 ([#111](https://github.com/mvlabat/bevy_egui/pull/111) by @DGriffin91).
+- Update Bevy to 0.8 ([#111](https://github.com/vladbat00/bevy_egui/pull/111) by @DGriffin91).
 
 ## [0.14.0] - 1-May-2022
 
 ### Added
 
-- Add new_tab support for open_url ([#96](https://github.com/mvlabat/bevy_egui/pull/96) by @Azorlogh).
+- Add new_tab support for open_url ([#96](https://github.com/vladbat00/bevy_egui/pull/96) by @Azorlogh).
   - `EguiSettings` has also got the `default_open_url_target` parameter to make the default behaviour on left mouse click configurable.
-- Update Egui to 0.18 ([#99](https://github.com/mvlabat/bevy_egui/pull/99)).
+- Update Egui to 0.18 ([#99](https://github.com/vladbat00/bevy_egui/pull/99)).
 
 ### Changed
 
@@ -284,46 +284,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improve wgsl readability and introduce minor optimisations ([#95](https://github.com/mvlabat/bevy_egui/pull/95) by @lain-dono).
-- Remove duplicate EguiPipeline resource initialization ([#98](https://github.com/mvlabat/bevy_egui/pull/98) by @lain-dono).
-- Fix color blending for user textures ([#100](https://github.com/mvlabat/bevy_egui/pull/100)).
+- Improve wgsl readability and introduce minor optimisations ([#95](https://github.com/vladbat00/bevy_egui/pull/95) by @lain-dono).
+- Remove duplicate EguiPipeline resource initialization ([#98](https://github.com/vladbat00/bevy_egui/pull/98) by @lain-dono).
+- Fix color blending for user textures ([#100](https://github.com/vladbat00/bevy_egui/pull/100)).
 
 ## [0.13.0] - 16-Apr-2022
 
 ### Changed
 
-- Update Bevy to 0.7 ([#79](https://github.com/mvlabat/bevy_egui/pull/79) by @aevyrie and @forbjok).
-- Return egui::TextureId on removal ([#81](https://github.com/mvlabat/bevy_egui/pull/81) by @Shatur).
-- Add `must_use` attributes to methods ([#82](https://github.com/mvlabat/bevy_egui/pull/82)).
+- Update Bevy to 0.7 ([#79](https://github.com/vladbat00/bevy_egui/pull/79) by @aevyrie and @forbjok).
+- Return egui::TextureId on removal ([#81](https://github.com/vladbat00/bevy_egui/pull/81) by @Shatur).
+- Add `must_use` attributes to methods ([#82](https://github.com/vladbat00/bevy_egui/pull/82)).
 
 ### Fixed
 
-- Remove unnecessary image clone allocation ([#84](https://github.com/mvlabat/bevy_egui/pull/84) by @frewsxcv).
-- Avoid allocations by utilizing `HashMap::iter_mut` ([#83](https://github.com/mvlabat/bevy_egui/pull/83) by @frewsxcv).
-- Remove unnecessary swap texture clone ([#85](https://github.com/mvlabat/bevy_egui/pull/85) by @frewsxcv).
+- Remove unnecessary image clone allocation ([#84](https://github.com/vladbat00/bevy_egui/pull/84) by @frewsxcv).
+- Avoid allocations by utilizing `HashMap::iter_mut` ([#83](https://github.com/vladbat00/bevy_egui/pull/83) by @frewsxcv).
+- Remove unnecessary swap texture clone ([#85](https://github.com/vladbat00/bevy_egui/pull/85) by @frewsxcv).
 
 ## [0.12.1] - 13-Mar-2022
 
 ### Added
 
-- Add a function to get image id ([#80](https://github.com/mvlabat/bevy_egui/pull/80) by @Shatur).
+- Add a function to get image id ([#80](https://github.com/vladbat00/bevy_egui/pull/80) by @Shatur).
 
 ## [0.12.0] - 12-Mar-2022
 
 ### Added
 
-- Add side panel example ([#73](https://github.com/mvlabat/bevy_egui/pull/73)).
+- Add side panel example ([#73](https://github.com/vladbat00/bevy_egui/pull/73)).
 
 ### Changed
 
-- Update Egui to 0.17 ([#78](https://github.com/mvlabat/bevy_egui/pull/78) by @emilk).
+- Update Egui to 0.17 ([#78](https://github.com/vladbat00/bevy_egui/pull/78) by @emilk).
 
 ### Fixed
 
-- User texture ids are now tracked internally ([#71](https://github.com/mvlabat/bevy_egui/pull/71)).
+- User texture ids are now tracked internally ([#71](https://github.com/vladbat00/bevy_egui/pull/71)).
   - Instead of using `set_egui_texture`, you can now use `add_image` which returns a texture id itself
-    (see the updated [ui](https://github.com/mvlabat/bevy_egui/blob/c611671603a70e5956ba06f77bb94851c7ced659/examples/ui.rs) example).
-- Switch to `arboard` for managing clipboard ([#72](https://github.com/mvlabat/bevy_egui/pull/72)).
+    (see the updated [ui](https://github.com/vladbat00/bevy_egui/blob/c611671603a70e5956ba06f77bb94851c7ced659/examples/ui.rs) example).
+- Switch to `arboard` for managing clipboard ([#72](https://github.com/vladbat00/bevy_egui/pull/72)).
 
 ## [0.11.1] - 4-Feb-2022
 
@@ -335,18 +335,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Introduce mutable getters for EguiContext, feature gate immutable ones ([#64](https://github.com/mvlabat/bevy_egui/pull/63)).
+- Introduce mutable getters for EguiContext, feature gate immutable ones ([#64](https://github.com/vladbat00/bevy_egui/pull/63)).
   - If you used `bevy_egui` without the `multi_threaded` feature, you'll need to change every `ctx` call to `ctx_mut`.
 
 ## [0.10.3] - 29-Jan-2022
 
 ### Added
 
-- Feature `multi_threaded`, to avoid using `egui/multi_threaded` ([#63](https://github.com/mvlabat/bevy_egui/pull/63) by @ndarilek).
+- Feature `multi_threaded`, to avoid using `egui/multi_threaded` ([#63](https://github.com/vladbat00/bevy_egui/pull/63) by @ndarilek).
 
 ### Fixed
 
-- WGPU crash on minimizing a window ([#62](https://github.com/mvlabat/bevy_egui/pull/62) by @aevyrie).
+- WGPU crash on minimizing a window ([#62](https://github.com/vladbat00/bevy_egui/pull/62) by @aevyrie).
 
 ## [0.10.2] - 23-Jan-2022
 
@@ -365,29 +365,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Headless mode support ([#51](https://github.com/mvlabat/bevy_egui/pull/51) by @Shatur).
+- Headless mode support ([#51](https://github.com/vladbat00/bevy_egui/pull/51) by @Shatur).
 
 ### Fixed
 
-- Egui pass now runs after `bevy_ui` ([#53](https://github.com/mvlabat/bevy_egui/pull/53) by @jakobhellermann).
+- Egui pass now runs after `bevy_ui` ([#53](https://github.com/vladbat00/bevy_egui/pull/53) by @jakobhellermann).
 
 ## [0.10.0] - 8-Jan-2022
 
 ### Changed
 
-- Update Bevy to 0.6 ([#25](https://github.com/mvlabat/bevy_egui/pull/25) by @jakobhellermann).
+- Update Bevy to 0.6 ([#25](https://github.com/vladbat00/bevy_egui/pull/25) by @jakobhellermann).
 
 ## [0.9.0] - 1-Jan-2022
 
 ### Changed
 
-- Update Egui to 0.16 ([#49](https://github.com/mvlabat/bevy_egui/pull/49) by @Meshiest).
+- Update Egui to 0.16 ([#49](https://github.com/vladbat00/bevy_egui/pull/49) by @Meshiest).
 
 ## [0.8.0] - 27-Nov-2021
 
 ### Changed
 
-- Update Egui to 0.15.0 ([#45](https://github.com/mvlabat/bevy_egui/pull/45)).
+- Update Egui to 0.15.0 ([#45](https://github.com/vladbat00/bevy_egui/pull/45)).
 
 ## [0.7.1] - 06-Oct-2021
 
@@ -397,19 +397,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Initialize egui contexts during startup (fixes [#41](https://github.com/mvlabat/bevy_egui/issues/41)).
+- Initialize egui contexts during startup (fixes [#41](https://github.com/vladbat00/bevy_egui/issues/41)).
 
 ## [0.7.0] - 05-Sep-2021
 
 ### Changed
 
-- Update Egui to 0.14.0 ([#38](https://github.com/mvlabat/bevy_egui/pull/38)).
+- Update Egui to 0.14.0 ([#38](https://github.com/vladbat00/bevy_egui/pull/38)).
 
 ## [0.6.2] - 15-Aug-2021
 
 ### Fixed
 
-- Fix receiving input when holding a button ([#37](https://github.com/mvlabat/bevy_egui/pull/37)).
+- Fix receiving input when holding a button ([#37](https://github.com/vladbat00/bevy_egui/pull/37)).
 
 ## [0.6.1] - 20-Jul-2021
 
@@ -433,14 +433,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Better error message for a missing Egui context ([#24](https://github.com/mvlabat/bevy_egui/pull/24) by @jakobhellermann).
-- Add `try_ctx_for_window` function ([#20](https://github.com/mvlabat/bevy_egui/pull/20) by @jakobhellermann).
+- Better error message for a missing Egui context ([#24](https://github.com/vladbat00/bevy_egui/pull/24) by @jakobhellermann).
+- Add `try_ctx_for_window` function ([#20](https://github.com/vladbat00/bevy_egui/pull/20) by @jakobhellermann).
 
 ## [0.4.1] - 24-Apr-2021
 
 ### Fixed
 
-- Fix crashes related to invalid scissor or window size ([#18](https://github.com/mvlabat/bevy_egui/pull/18)).
+- Fix crashes related to invalid scissor or window size ([#18](https://github.com/vladbat00/bevy_egui/pull/18)).
 
 ## [0.4.0] - 10-Apr-2021
 
@@ -448,11 +448,11 @@ Huge thanks to @jakobhellermann and @Weasy666 for contributing to this release!
 
 ### Added
 
-- Implement multiple windows support ([#14](https://github.com/mvlabat/bevy_egui/pull/14) by @jakobhellermann).
+- Implement multiple windows support ([#14](https://github.com/vladbat00/bevy_egui/pull/14) by @jakobhellermann).
 
 ### Changed
 
-- Update Egui to 0.11.0 ([#12](https://github.com/mvlabat/bevy_egui/pull/12) by @Weasy666 and @jakobhellermann).
+- Update Egui to 0.11.0 ([#12](https://github.com/vladbat00/bevy_egui/pull/12) by @Weasy666 and @jakobhellermann).
 
 ## [0.3.0] - 02-Mar-2021
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["mvlabat <mvlabat@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"
 edition = "2021"
-repository = "https://github.com/mvlabat/bevy_egui"
+repository = "https://github.com/vladbat00/bevy_egui"
 exclude = ["assets/**/*", ".github/**/*"]
 
 [package.metadata.docs.rs]

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -182,7 +182,7 @@ fn ui_example_system(
         ui.heading("Egui Template");
         ui.hyperlink("https://github.com/emilk/egui_template");
         ui.add(egui::github_link_file_line!(
-            "https://github.com/mvlabat/bevy_egui/blob/main/",
+            "https://github.com/vladbat00/bevy_egui/blob/main/",
             "Direct link to source code."
         ));
         egui::warn_if_debug_build(ui);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@
 //!
 //! **Trying out:**
 //!
-//! An example WASM project is live at [mvlabat.github.io/bevy_egui_web_showcase](https://mvlabat.github.io/bevy_egui_web_showcase/index.html) [[source](https://github.com/mvlabat/bevy_egui_web_showcase)].
+//! An example WASM project is live at [vladbat00.github.io/bevy_egui_web_showcase](https://vladbat00.github.io/bevy_egui_web_showcase/index.html) [[source](https://github.com/vladbat00/bevy_egui_web_showcase)].
 //!
 //! **Features:**
 //! - Desktop and web platforms support
 //! - Clipboard (web support is limited to the same window, see [rust-windowing/winit#1829](https://github.com/rust-windowing/winit/issues/1829))
 //! - Opening URLs
-//! - Multiple windows support (see [./examples/two_windows.rs](https://github.com/mvlabat/bevy_egui/blob/v0.20.1/examples/two_windows.rs))
+//! - Multiple windows support (see [./examples/two_windows.rs](https://github.com/vladbat00/bevy_egui/blob/v0.20.1/examples/two_windows.rs))
 //!
 //! `bevy_egui` can be compiled with using only `bevy` and `egui` as dependencies: `manage_clipboard` and `open_url` features,
 //! that require additional crates, can be disabled.
@@ -40,7 +40,7 @@
 //! }
 //! ```
 //!
-//! For a more advanced example, see [examples/ui.rs](https://github.com/mvlabat/bevy_egui/blob/v0.20.1/examples/ui.rs).
+//! For a more advanced example, see [examples/ui.rs](https://github.com/vladbat00/bevy_egui/blob/v0.20.1/examples/ui.rs).
 //!
 //! ```bash
 //! cargo run --example ui


### PR DESCRIPTION
This commit fixes the broken links to the old github page (before the bevy_egui creator changed their github username).

This should replace the broken links in:

- the library source (src/lib.rs)
- the changelog
- ui example
- Cargo.toml

Any issues let me know!