### PR TITLE
Picking feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["manage_clipboard", "open_url", "default_fonts", "render"]
+default = ["manage_clipboard", "open_url", "default_fonts", "render", "picking"]
 immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local", "bytemuck"]
 open_url = ["webbrowser"]
@@ -24,13 +24,13 @@ default_fonts = ["egui/default_fonts"]
 render = [
     "bevy_asset",
     "bevy_image",
-    "bevy_picking",
     "bevy_render",
     "encase",
     "bytemuck",
     "egui/bytemuck",
     "wgpu-types",
 ]
+picking = ["bevy_picking"]
 serde = ["egui/serde"]
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_input_events = []
@@ -84,10 +84,12 @@ webbrowser = { version = "1.0.1", optional = true }
 bytemuck = { version = "1", optional = true }
 bevy_asset = { version = "0.15.0", optional = true }
 bevy_image = { version = "0.15.0", optional = true }
-bevy_picking = { version = "0.15.0", optional = true }
 bevy_render = { version = "0.15.0", optional = true }
 encase = { version = "0.10", optional = true }
 wgpu-types = { version = "23.0", optional = true }
+
+# `picking` feature
+bevy_picking = { version = "0.15.0", optional = true }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,9 +156,10 @@ use bevy_picking::{
     pointer::{PointerId, PointerLocation},
 };
 use bevy_reflect::Reflect;
+#[cfg(feature = "picking")]
+use bevy_render::camera::NormalizedRenderTarget;
 #[cfg(feature = "render")]
 use bevy_render::{
-    camera::NormalizedRenderTarget,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     render_resource::{LoadOp, SpecializedRenderPipelines},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ use bevy_ecs::{
 use bevy_image::{Image, ImageSampler};
 use bevy_input::InputSystem;
 use bevy_log as log;
-#[cfg(feature = "render")]
+#[cfg(feature = "picking")]
 use bevy_picking::{
     backend::{HitData, PointerHits},
     pointer::{PointerId, PointerLocation},
@@ -227,7 +227,7 @@ pub struct EguiContextSettings {
     #[cfg(feature = "open_url")]
     pub default_open_url_target: Option<String>,
     /// Controls if Egui should capture pointer input when using [`bevy_picking`] (i.e. suppress `bevy_picking` events when a pointer is over an Egui window).
-    #[cfg(feature = "render")]
+    #[cfg(feature = "picking")]
     pub capture_pointer_input: bool,
     /// Controls running of the input systems.
     pub input_system_settings: EguiInputSystemSettings,
@@ -251,7 +251,7 @@ impl Default for EguiContextSettings {
             scale_factor: 1.0,
             #[cfg(feature = "open_url")]
             default_open_url_target: None,
-            #[cfg(feature = "render")]
+            #[cfg(feature = "picking")]
             capture_pointer_input: true,
             input_system_settings: EguiInputSystemSettings::default(),
         }
@@ -980,7 +980,7 @@ impl Plugin for EguiPlugin {
             PostUpdate,
             process_output_system.in_set(EguiPostUpdateSet::ProcessOutput),
         );
-        #[cfg(feature = "render")]
+        #[cfg(feature = "picking")]
         app.add_systems(PostUpdate, capture_pointer_input_system);
 
         #[cfg(feature = "render")]
@@ -1180,11 +1180,11 @@ impl EguiClipboard {
 }
 
 /// The ordering value used for [`bevy_picking`].
-#[cfg(feature = "render")]
+#[cfg(feature = "picking")]
 pub const PICKING_ORDER: f32 = 1_000_000.0;
 
 /// Captures pointers on egui windows for [`bevy_picking`].
-#[cfg(feature = "render")]
+#[cfg(feature = "picking")]
 pub fn capture_pointer_input_system(
     pointers: Query<(&PointerId, &PointerLocation)>,
     mut egui_context: Query<(Entity, &mut EguiContext, &EguiContextSettings), With<Window>>,


### PR DESCRIPTION
I like my binaries as small as possible, `bevy_picking` takes up ~500KB (according to `cargo bloat`). This puts `bevy_picking` behind it's own feature flag (`picking`) so that you can disable it if you want to.