### PR TITLE
Relax dependency version constraints for improved compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_egui"
-version = "0.33.0"
+version = "0.33.1"
 # Needed for LazyLock https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 rust-version = "1.80.0"
 authors = ["vladbat00 <vladyslav.batyrenko@gmail.com>"]
@@ -68,40 +68,40 @@ required-features = ["picking", "render", "bevy/bevy_gizmos"]
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
-bevy_app = "0.15.0"
-bevy_derive = "0.15.0"
-bevy_ecs = "0.15.0"
-bevy_input = "0.15.0"
-bevy_log = "0.15.0"
-bevy_math = "0.15.0"
-bevy_reflect = "0.15.0"
-bevy_time = "0.15.0"
-bevy_utils = "0.15.0"
-bevy_winit = { version = "0.15.0", features = ["custom_cursor"] }
-bevy_window = "0.15.0"
+bevy_app = "0.15"
+bevy_derive = "0.15"
+bevy_ecs = "0.15"
+bevy_input = "0.15"
+bevy_log = "0.15"
+bevy_math = "0.15"
+bevy_reflect = "0.15"
+bevy_time = "0.15"
+bevy_utils = "0.15"
+bevy_winit = { version = "0.15", features = ["custom_cursor"] }
+bevy_window = "0.15"
 
 # `open_url` feature
 webbrowser = { version = "1.0.1", optional = true }
 
 # `render` feature
 bytemuck = { version = "1", optional = true }
-bevy_asset = { version = "0.15.0", optional = true }
-bevy_image = { version = "0.15.0", optional = true }
-bevy_render = { version = "0.15.0", optional = true }
+bevy_asset = { version = "0.15", optional = true }
+bevy_image = { version = "0.15", optional = true }
+bevy_render = { version = "0.15", optional = true }
 encase = { version = "0.10", optional = true }
 wgpu-types = { version = "23.0", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.15.0", optional = true }
+bevy_picking = { version = "0.15", optional = true }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
-arboard = { version = "3.2.0", optional = true }
-thread_local = { version = "1.1.0", optional = true }
+arboard = { version = "3.2", optional = true }
+thread_local = { version = "1.1", optional = true }
 
 [dev-dependencies]
-version-sync = "0.9.4"
-bevy = { version = "0.15.0", default-features = false, features = [
+version-sync = "0.9"
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",
@@ -119,7 +119,7 @@ egui = { version = "0.31", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"
-web-sys = { version = "0.3.74", features = [
+web-sys = { version = "0.3", features = [
     "Clipboard",
     "ClipboardEvent",
     "ClipboardItem",
@@ -134,8 +134,8 @@ web-sys = { version = "0.3.74", features = [
     "TouchEvent",
     "Window",
 ] }
-image = { version = "0.25.5", features = ["png"] } # For copying images
-js-sys = "0.3.63"
-wasm-bindgen = "0.2.84"
-wasm-bindgen-futures = "0.4.36"
-crossbeam-channel = "0.5.8"
+image = { version = "0.25", features = ["png"] } # For copying images
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+crossbeam-channel = "0.5"


### PR DESCRIPTION
## Description

This PR relaxes version constraints across the crate's dependencies.

## Changes:
* Updated version constraints for all dependencies to use minor version specifications instead of patch versions
* Bumped crate version to 0.33.1

## Why this is needed:
The exact version specifications were causing dependency resolution conflicts when `bevy_egui` was used in projects that also depend on other crates using different patch versions of these dependencies. By relaxing the constraints to minor version level, we maintain compatibility while allowing Cargo to resolve to the most appropriate patch version.