### PR TITLE
Implement absorbing inputs and Egui input run condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ serde = ["egui/serde"]
 log_input_events = []
 
 [[example]]
+name = "absorb_input"
+required-features = ["render"]
+[[example]]
 name = "color_test"
 required-features = ["render"]
 [[example]]

--- a/examples/absorb_input.rs
+++ b/examples/absorb_input.rs
@@ -14,6 +14,11 @@ fn main() {
         .add_plugins(EguiPlugin)
         .add_systems(Startup, setup_scene_system)
         .add_systems(Update, ui_system)
+        // You can wrap your systems with the `egui_wants_input` run condition if you
+        // want to disable them while Egui is using input.
+        //
+        // As an alternative (a less safe one), you can set `EguiGlobalSettings::enable_absorb_bevy_input_system`
+        // to true to let Egui absorb all input events (see `ui_system` for the usage example).
         .add_systems(Update, input_system.run_if(not(egui_wants_input)))
         .run();
 }

--- a/examples/absorb_input.rs
+++ b/examples/absorb_input.rs
@@ -1,0 +1,144 @@
+use bevy::{
+    color::palettes::{basic::PURPLE, css::YELLOW},
+    prelude::*,
+};
+use bevy_egui::{egui, input::egui_wants_input, EguiContexts, EguiGlobalSettings, EguiPlugin};
+use bevy_input::{
+    keyboard::KeyboardInput,
+    mouse::{MouseButtonInput, MouseWheel},
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(EguiPlugin)
+        .add_systems(Startup, setup_scene_system)
+        .add_systems(Update, ui_system)
+        .add_systems(Update, input_system.run_if(not(egui_wants_input)))
+        .run();
+}
+
+#[derive(Resource, Clone)]
+struct Materials {
+    yellow: MeshMaterial2d<ColorMaterial>,
+    purple: MeshMaterial2d<ColorMaterial>,
+}
+
+fn setup_scene_system(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut color_materials: ResMut<Assets<ColorMaterial>>,
+) {
+    let materials = Materials {
+        yellow: MeshMaterial2d(color_materials.add(Color::from(YELLOW))),
+        purple: MeshMaterial2d(color_materials.add(Color::from(PURPLE))),
+    };
+    commands.insert_resource(materials.clone());
+
+    commands.spawn(Camera2d);
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::default())),
+        materials.purple,
+        Transform::default().with_scale(Vec3::splat(128.)),
+    ));
+}
+
+struct LoremIpsum(String);
+
+impl Default for LoremIpsum {
+    fn default() -> Self {
+        Self("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".to_string())
+    }
+}
+
+#[derive(Default)]
+struct LastEvents {
+    keyboard_input: Option<KeyboardInput>,
+    mouse_button_input: Option<MouseButtonInput>,
+    mouse_wheel: Option<MouseWheel>,
+}
+
+fn ui_system(
+    mut contexts: EguiContexts,
+    mut egui_global_settings: ResMut<EguiGlobalSettings>,
+    mut text: Local<LoremIpsum>,
+    mut last_events: Local<LastEvents>,
+    mut keyboard_input_events: EventReader<KeyboardInput>,
+    mut mouse_button_input_events: EventReader<MouseButtonInput>,
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+) {
+    if let Some(ev) = keyboard_input_events.read().last() {
+        last_events.keyboard_input = Some(ev.clone());
+    }
+    if let Some(ev) = mouse_button_input_events.read().last() {
+        last_events.mouse_button_input = Some(*ev);
+    }
+    if let Some(ev) = mouse_wheel_events.read().last() {
+        last_events.mouse_wheel = Some(*ev);
+    }
+
+    egui::Window::new("Absorb Input")
+        .max_size([300.0, 200.0])
+        .vscroll(true)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.checkbox(
+                &mut egui_global_settings.enable_absorb_bevy_input_system,
+                "Absorb all input events",
+            );
+
+            ui.separator();
+
+            ui.label(format!(
+                "Last keyboard button event: {:?}",
+                last_events.keyboard_input
+            ));
+            ui.label(format!(
+                "Last mouse button event: {:?}",
+                last_events.mouse_button_input
+            ));
+            ui.label(format!(
+                "Last mouse wheel event: {:?}",
+                last_events.mouse_wheel
+            ));
+
+            ui.separator();
+
+            ui.label("A text field to test absorbing keyboard events");
+            ui.text_edit_multiline(&mut text.0);
+        });
+}
+
+fn input_system(
+    materials: Res<Materials>,
+    mesh: Single<(&mut Transform, &mut MeshMaterial2d<ColorMaterial>), Without<Camera2d>>,
+    mouse_button_input: Res<ButtonInput<MouseButton>>,
+    keyboard_button_input: Res<ButtonInput<KeyCode>>,
+    mut mouse_wheel_event_reader: EventReader<MouseWheel>,
+) {
+    let (mut transform, mut material) = mesh.into_inner();
+
+    if mouse_button_input.just_pressed(MouseButton::Left) {
+        *material = if materials.yellow.0 == material.0 {
+            materials.purple.clone()
+        } else {
+            materials.yellow.clone()
+        }
+    }
+
+    if keyboard_button_input.pressed(KeyCode::KeyA) {
+        transform.translation.x -= 5.0;
+    }
+    if keyboard_button_input.pressed(KeyCode::KeyD) {
+        transform.translation.x += 5.0;
+    }
+    if keyboard_button_input.pressed(KeyCode::KeyS) {
+        transform.translation.y -= 5.0;
+    }
+    if keyboard_button_input.pressed(KeyCode::KeyW) {
+        transform.translation.y += 5.0;
+    }
+
+    for ev in mouse_wheel_event_reader.read() {
+        transform.scale += ev.y;
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 use bevy_ecs::prelude::*;
 use bevy_input::{
-    keyboard::{Key, KeyboardFocusLost, KeyboardInput},
+    keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
-    ButtonState,
+    ButtonInput, ButtonState,
 };
 use bevy_log as log;
 use bevy_time::{Real, Time};
@@ -807,4 +807,61 @@ pub fn write_egui_input_system(
         egui_input.modifiers = modifier_keys_state.to_egui_modifiers();
         egui_input.time = Some(time.elapsed_secs_f64());
     }
+}
+
+/// Clears Bevy input event buffers and resets [`ButtonInput`] resources if Egui requires is
+/// using pointer or keyboard (see the [`write_egui_wants_input_system`] run condition).
+///
+/// This system isn't run by default, see [`EguiGlobalSettings::enable_absorb_bevy_input_system`].
+pub fn absorb_bevy_input_system(
+    mut mouse_input: ResMut<ButtonInput<MouseButton>>,
+    mut keyboard_input: ResMut<ButtonInput<KeyCode>>,
+    mut keyboard_input_events: ResMut<Events<KeyboardInput>>,
+    mut mouse_wheel_events: ResMut<Events<MouseWheel>>,
+    mut mouse_button_input_events: ResMut<Events<MouseButtonInput>>,
+) {
+    let modifiers = [
+        KeyCode::SuperLeft,
+        KeyCode::SuperRight,
+        KeyCode::ControlLeft,
+        KeyCode::ControlRight,
+        KeyCode::AltLeft,
+        KeyCode::AltRight,
+        KeyCode::ShiftLeft,
+        KeyCode::ShiftRight,
+    ];
+
+    let pressed = modifiers.map(|key| keyboard_input.pressed(key).then_some(key));
+
+    mouse_input.reset_all();
+    keyboard_input.reset_all();
+    keyboard_input_events.clear();
+    mouse_wheel_events.clear();
+    mouse_button_input_events.clear();
+
+    for key in pressed.into_iter().flatten() {
+        keyboard_input.press(key);
+    }
+}
+
+/// Stores whether there's an Egui context using pointer or keyboard.
+#[derive(Resource, Clone, Debug, Default)]
+pub struct EguiWantsInput(bool);
+
+/// Updates the [`EguiWantsInput`] resource.
+pub fn write_egui_wants_input_system(
+    mut egui_context_query: Query<&mut EguiContext>,
+    mut egui_wants_input: ResMut<EguiWantsInput>,
+) {
+    egui_wants_input.0 = egui_context_query.iter_mut().any(|mut ctx| {
+        let egui_ctx = ctx.get_mut();
+        egui_ctx.wants_pointer_input()
+            || egui_ctx.wants_keyboard_input()
+            || egui_ctx.is_pointer_over_area()
+    });
+}
+
+/// Returns `true` if any Egui context is using pointer or keyboard.
+pub fn egui_wants_input(egui_wants_input_resource: Res<EguiWantsInput>) -> bool {
+    egui_wants_input_resource.0
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -809,10 +809,23 @@ pub fn write_egui_input_system(
     }
 }
 
-/// Clears Bevy input event buffers and resets [`ButtonInput`] resources if Egui requires is
-/// using pointer or keyboard (see the [`write_egui_wants_input_system`] run condition).
+/// Clears Bevy input event buffers and resets [`ButtonInput`] resources if Egui
+/// is using pointer or keyboard (see the [`write_egui_wants_input_system`] run condition).
 ///
-/// This system isn't run by default, see [`EguiGlobalSettings::enable_absorb_bevy_input_system`].
+/// This system isn't run by default, set [`EguiGlobalSettings::enable_absorb_bevy_input_system`]
+/// to `true` to enable it.
+///
+/// ## Considerations
+///
+/// Enabling this system makes an assumption that `bevy_egui` takes priority in input handling
+/// over other plugins and systems. This should work ok as long as there's no other system
+/// clearing events the same way that might be in conflict with `bevy_egui`, and there's
+/// no other system that needs a non-interrupted flow of events.
+///
+/// ## Alternative
+///
+/// A safer alternative is to apply `run_if(not(egui_wants_input))` to your systems
+/// that need to be disabled while Egui is using input (see the [`egui_wants_input`] run condition).
 pub fn absorb_bevy_input_system(
     mut mouse_input: ResMut<ButtonInput<MouseButton>>,
     mut keyboard_input: ResMut<ButtonInput<KeyCode>>,
@@ -833,6 +846,8 @@ pub fn absorb_bevy_input_system(
 
     let pressed = modifiers.map(|key| keyboard_input.pressed(key).then_some(key));
 
+    // TODO: the list of events is definitely not comprehensive, but it should at least cover
+    //  the most popular use-cases. We can add more on request.
     mouse_input.reset_all();
     keyboard_input.reset_all();
     keyboard_input_events.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,18 @@ pub struct EguiGlobalSettings {
     /// Controls running of the input systems.
     pub input_system_settings: EguiInputSystemSettings,
     /// Controls running of the [`absorb_bevy_input_system`] system, disabled by default.
+    ///
+    /// ## Considerations
+    ///
+    /// Enabling this system makes an assumption that `bevy_egui` takes priority in input handling
+    /// over other plugins and systems. This should work ok as long as there's no other system
+    /// clearing events the same way that might be in conflict with `bevy_egui`, and there's
+    /// no other system that needs a non-interrupted flow of events.
+    ///
+    /// ## Alternative
+    ///
+    /// Apply `run_if(not(egui_wants_input))` to your systems that need to be disabled while
+    /// Egui is using input.
     pub enable_absorb_bevy_input_system: bool,
 }
 


### PR DESCRIPTION
Closes #47, #218

- Add `egui_wants_input` run condition
- Add `absorb_bevy_input_system` system (disabled by default, can be enabled with `EguiGlobalSettings::enable_absorb_bevy_input_system`)