### PR TITLE
Implement multipass support (attempt 2, using custom schedules)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ required-features = ["render"]
 name = "render_to_image_widget"
 required-features = ["render"]
 [[example]]
+name = "run_manually"
+required-features = ["render"]
+[[example]]
 name = "side_panel_2d"
 required-features = ["render"]
 [[example]]
@@ -55,9 +58,6 @@ name = "side_panel_3d"
 required-features = ["render"]
 [[example]]
 name = "simple"
-required-features = ["render"]
-[[example]]
-name = "simple_multipass"
 required-features = ["render"]
 [[example]]
 name = "two_windows"

--- a/examples/absorb_input.rs
+++ b/examples/absorb_input.rs
@@ -1,19 +1,23 @@
 use bevy::{
     color::palettes::{basic::PURPLE, css::YELLOW},
+    input::{
+        keyboard::KeyboardInput,
+        mouse::{MouseButtonInput, MouseWheel},
+    },
     prelude::*,
 };
-use bevy_egui::{egui, input::egui_wants_input, EguiContexts, EguiGlobalSettings, EguiPlugin};
-use bevy_input::{
-    keyboard::KeyboardInput,
-    mouse::{MouseButtonInput, MouseWheel},
+use bevy_egui::{
+    egui, input::egui_wants_input, EguiContextPass, EguiContexts, EguiGlobalSettings, EguiPlugin,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .add_systems(Startup, setup_scene_system)
-        .add_systems(Update, ui_system)
+        .add_systems(EguiContextPass, ui_system)
         // You can wrap your systems with the `egui_wants_input` run condition if you
         // want to disable them while Egui is using input.
         //
@@ -63,6 +67,7 @@ struct LastEvents {
     mouse_wheel: Option<MouseWheel>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ui_system(
     mut contexts: EguiContexts,
     mut egui_global_settings: ResMut<EguiGlobalSettings>,

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -8,15 +8,19 @@ use bevy::{
         view::RenderLayers,
     },
 };
-use bevy_egui::{egui::Widget, EguiContexts, EguiPlugin, EguiUserTextures};
+use bevy_egui::{egui::Widget, EguiContextPass, EguiContexts, EguiPlugin, EguiUserTextures};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .add_systems(Startup, setup)
-        .add_systems(Update, rotator_system)
-        .add_systems(Update, render_to_image_example_system)
+        .add_systems(
+            EguiContextPass,
+            (rotator_system, render_to_image_example_system),
+        )
         .run();
 }
 

--- a/examples/run_manually.rs
+++ b/examples/run_manually.rs
@@ -1,14 +1,15 @@
-use std::num::NonZero;
-
 use bevy::prelude::*;
 use bevy_egui::{
     EguiContext, EguiContextSettings, EguiFullOutput, EguiInput, EguiPlugin, EguiStartupSet,
 };
+use std::num::NonZero;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: false,
+        })
         .add_systems(
             PreStartup,
             configure_context.after(EguiStartupSet::InitContexts),

--- a/examples/side_panel_2d.rs
+++ b/examples/side_panel_2d.rs
@@ -1,13 +1,15 @@
 use bevy::{prelude::*, render::camera::Viewport, window::PrimaryWindow};
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
 
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::srgb(0.25, 0.25, 0.25)))
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .add_systems(Startup, setup_system)
-        .add_systems(Update, ui_example_system)
+        .add_systems(EguiContextPass, ui_example_system)
         .run();
 }
 

--- a/examples/side_panel_3d.rs
+++ b/examples/side_panel_3d.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, window::PrimaryWindow, winit::WinitSettings};
-use bevy_egui::{EguiContexts, EguiPlugin};
+use bevy_egui::{EguiContextPass, EguiContexts, EguiPlugin};
 
 #[derive(Default, Resource)]
 struct OccupiedScreenSpace {
@@ -18,11 +18,15 @@ fn main() {
     App::new()
         .insert_resource(WinitSettings::desktop_app())
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .init_resource::<OccupiedScreenSpace>()
         .add_systems(Startup, setup_system)
-        .add_systems(Update, ui_example_system)
-        .add_systems(Update, update_camera_transform_system)
+        .add_systems(
+            EguiContextPass,
+            (ui_example_system, update_camera_transform_system),
+        )
         .run();
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,15 @@
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         // Systems that create Egui widgets should be run during the `CoreSet::Update` set,
         // or after the `EguiPreUpdateSet::BeginPass` system (which belongs to the `CoreSet::PreUpdate` set).
-        .add_systems(Update, ui_example_system)
+        .add_systems(EguiContextPass, ui_example_system)
         .run();
 }
 

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -3,22 +3,30 @@ use bevy::{
     render::camera::RenderTarget,
     window::{PresentMode, PrimaryWindow, WindowRef, WindowResolution},
 };
-use bevy_egui::{EguiContext, EguiPlugin, EguiUserTextures};
+use bevy_ecs::schedule::ScheduleLabel;
+use bevy_egui::{
+    EguiContext, EguiContextPass, EguiMultipassSchedule, EguiPlugin, EguiUserTextures,
+};
 
 #[derive(Resource)]
 struct Images {
     bevy_icon: Handle<Image>,
 }
 
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SecondWindowContextPass;
+
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .init_resource::<SharedUiState>()
         .add_systems(Startup, load_assets_system)
         .add_systems(Startup, create_new_window_system)
-        .add_systems(Update, ui_first_window_system)
-        .add_systems(Update, ui_second_window_system);
+        .add_systems(EguiContextPass, ui_first_window_system)
+        .add_systems(SecondWindowContextPass, ui_second_window_system);
 
     app.run();
 }
@@ -26,12 +34,15 @@ fn main() {
 fn create_new_window_system(mut commands: Commands) {
     // Spawn a second window
     let second_window_id = commands
-        .spawn(Window {
-            title: "Second window".to_owned(),
-            resolution: WindowResolution::new(800.0, 600.0),
-            present_mode: PresentMode::AutoVsync,
-            ..Default::default()
-        })
+        .spawn((
+            Window {
+                title: "Second window".to_owned(),
+                resolution: WindowResolution::new(800.0, 600.0),
+                present_mode: PresentMode::AutoVsync,
+                ..Default::default()
+            },
+            EguiMultipassSchedule::new(SecondWindowContextPass),
+        ))
         .id();
 
     // second window camera

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -2,7 +2,7 @@ use bevy::{
     log::{Level, LogPlugin},
     prelude::*,
 };
-use bevy_egui::{EguiContextSettings, EguiContexts, EguiPlugin};
+use bevy_egui::{EguiContextPass, EguiContextSettings, EguiContexts, EguiPlugin};
 
 struct Images {
     bevy_icon: Handle<Image>,
@@ -43,11 +43,15 @@ fn main() {
                     ..default()
                 }),
         )
-        .add_plugins(EguiPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
         .add_systems(Startup, configure_visuals_system)
         .add_systems(Startup, configure_ui_state_system)
-        .add_systems(Update, update_ui_scale_factor_system)
-        .add_systems(Update, ui_example_system)
+        .add_systems(
+            EguiContextPass,
+            (ui_example_system, update_ui_scale_factor_system),
+        )
         .run();
 }
 #[derive(Default, Resource)]


### PR DESCRIPTION
Rewrite of #370 - observers are fun and games, but this approach seems to work better, since going multi-pass requires less changes now, and it's actually compatible with exclusive systems (which are crucial for bevy-inspector-egui and the likes).

This PR implements an experimental multi-pass mode support.

It doesn't introduce breaking changes apart from `EguiPlugin` receiving a new field: `enable_multipass_for_primary_context`. Even though there are alternative ways to opt-in for the multi-pass mode which don't bring breaking changes in, this was mainly done for the feature discoverability.

Users are encouraged to switch to the multi-pass mode (even though it's experimental for now, I hope the single-pass mode will be eventually phased out), and maintainers of plugins depending on `bevy_egui` should also adapt to the change, to support both modes. See the `EguiPlugin::enable_multipass_for_primary_context` documentation for more details.

Closes #358 