### PR TITLE
Fix missing egui file drag and drop events

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
             cache-${{ runner.os }}-cargo
       - name: Install dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libglib2.0-dev
       - run: cargo clippy --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
 
   clippy_wasm32:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,5 +201,5 @@ jobs:
             cache-test-cargo-${{ hashFiles('**/Cargo.toml') }}
             cache-test-cargo
       - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libglib2.0-dev libgtk-3-dev
       - run: cargo test --all

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
             cache-${{ runner.os }}-cargo
       - name: Install dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libglib2.0-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libglib2.0-dev libgtk-3-dev
       - run: cargo clippy --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
 
   clippy_wasm32:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,5 +201,5 @@ jobs:
             cache-test-cargo-${{ hashFiles('**/Cargo.toml') }}
             cache-test-cargo
       - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libglib2.0-dev libgtk-3-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - run: cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,6 @@ log_input_events = []
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_file_dnd_events = []
 
-# specifically for feature gating `rfd` from tests
-file_browse = ["rfd"]
-
 [[example]]
 name = "absorb_input"
 required-features = ["render"]
@@ -75,7 +72,7 @@ name = "render_egui_to_image"
 required-features = ["picking", "render", "bevy/bevy_gizmos"]
 [[example]]
 name = "file_browse"
-required-features = ["render", "file_browse"]
+required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
@@ -110,10 +107,6 @@ bevy_picking = { version = "0.16.0-rc", optional = true }
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
-
-# `file_browse` feature only, workaround dev-dependency
-[target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-rfd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ log_input_events = []
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_file_dnd_events = []
 
+# specifically for feature gating `rfd` from tests
+file_browse = ["rfd"]
+
 [[example]]
 name = "absorb_input"
 required-features = ["render"]
@@ -72,7 +75,7 @@ name = "render_egui_to_image"
 required-features = ["picking", "render", "bevy/bevy_gizmos"]
 [[example]]
 name = "file_browse"
-required-features = ["render"]
+required-features = ["render", "file_browse"]
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
@@ -108,6 +111,10 @@ bevy_picking = { version = "0.16.0-rc", optional = true }
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
+# `file_browse` feature only, workaround dev-dependency
+[target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dependencies]
+rfd = { version = "0.13", optional = true }
+
 [dev-dependencies]
 version-sync = "0.9.5"
 bevy = { version = "0.16.0-rc", default-features = false, features = [
@@ -128,9 +135,6 @@ bevy = { version = "0.16.0-rc", default-features = false, features = [
     "x11",
 ] }
 egui = { version = "0.31", default-features = false, features = ["bytemuck"] }
-
-[target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
-rfd = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,9 @@ bevy = { version = "0.16.0-rc", default-features = false, features = [
     "x11",
 ] }
 egui = { version = "0.31", default-features = false, features = ["bytemuck"] }
-rfd = "0.15.3"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
+rfd = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ picking = ["bevy_picking"]
 serde = ["egui/serde"]
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_input_events = []
+# The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
+log_file_dnd_events = []
 
 [[example]]
 name = "absorb_input"
@@ -123,6 +125,7 @@ bevy = { version = "0.16.0-rc", default-features = false, features = [
     "x11",
 ] }
 egui = { version = "0.31", default-features = false, features = ["bytemuck"] }
+rfd = "0.15.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ required-features = ["render"]
 [[example]]
 name = "render_egui_to_image"
 required-features = ["picking", "render", "bevy/bevy_gizmos"]
+[[example]]
+name = "file_browse"
+required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.31", default-features = false }

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -1,10 +1,5 @@
-#![cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
-
-use bevy::{
-    prelude::*,
-    tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
-};
-use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
+use bevy::prelude::*;
+use bevy_egui::{EguiContextPass, EguiPlugin};
 
 fn main() {
     App::new()
@@ -12,129 +7,141 @@ fn main() {
         .add_plugins(EguiPlugin {
             enable_multipass_for_primary_context: true,
         })
-        .add_systems(EguiContextPass, ui_system)
+        .add_systems(EguiContextPass, foo::ui_system)
         .run();
 }
 
-#[derive(Default)]
-pub struct MyState {
-    dropped_files: Vec<egui::DroppedFile>,
-    picked_path: Option<String>,
-}
+#[cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
+mod foo {
+    use bevy::{
+        prelude::*,
+        tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
+    };
+    use bevy_egui::{egui, EguiContexts};
 
-type DialogResponse = Option<rfd::FileHandle>;
+    #[derive(Default)]
+    pub struct MyState {
+        dropped_files: Vec<egui::DroppedFile>,
+        picked_path: Option<String>,
+    }
 
-// much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
-pub fn ui_system(
-    mut contexts: EguiContexts,
-    mut state: Local<MyState>,
-    mut file_dialog: Local<Option<Task<DialogResponse>>>,
-) {
-    let ctx = contexts.ctx_mut();
-    egui::CentralPanel::default().show(ctx, |ui| {
-        ui.label("Drag-and-drop files onto the window!");
+    type DialogResponse = Option<rfd::FileHandle>;
 
-        if let Some(file_response) = file_dialog
-            .as_mut()
-            .and_then(|task| block_on(poll_once(task)))
-        {
-            state.picked_path = file_response.map(|path| path.path().display().to_string());
-            *file_dialog = None;
-        }
+    // much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
+    pub fn ui_system(
+        mut contexts: EguiContexts,
+        mut state: Local<MyState>,
+        mut file_dialog: Local<Option<Task<DialogResponse>>>,
+    ) {
+        let ctx = contexts.ctx_mut();
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label("Drag-and-drop files onto the window!");
 
-        if ui.button("Open file…").clicked() {
-            *file_dialog =
-                Some(AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()));
-        }
-
-        if let Some(picked_path) = &state.picked_path {
-            ui.horizontal(|ui| {
-                ui.label("Picked file:");
-                ui.monospace(picked_path);
-            });
-        }
-
-        // Show dropped files (if any):
-        if !state.dropped_files.is_empty() {
-            ui.group(|ui| {
-                ui.label("Dropped files:");
-
-                for file in &state.dropped_files {
-                    let mut info = if let Some(path) = &file.path {
-                        path.display().to_string()
-                    } else if !file.name.is_empty() {
-                        file.name.clone()
-                    } else {
-                        "???".to_owned()
-                    };
-
-                    let mut additional_info = vec![];
-                    if !file.mime.is_empty() {
-                        additional_info.push(format!("type: {}", file.mime));
-                    }
-                    if let Some(bytes) = &file.bytes {
-                        additional_info.push(format!("{} bytes", bytes.len()));
-                    }
-                    if !additional_info.is_empty() {
-                        info += &format!(" ({})", additional_info.join(", "));
-                    }
-
-                    ui.label(info);
-                }
-            });
-        }
-    });
-
-    preview_files_being_dropped(ctx);
-
-    // Collect dropped files:
-    ctx.input(|i| {
-        if !i.raw.dropped_files.is_empty() {
-            state.dropped_files.clone_from(&i.raw.dropped_files);
-        }
-    });
-
-    ctx.input(|i| {
-        if i.raw.modifiers.ctrl {
-            info!("ctrl pressed");
-        }
-    })
-}
-
-fn preview_files_being_dropped(ctx: &egui::Context) {
-    use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
-    use std::fmt::Write as _;
-
-    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
-        let text = ctx.input(|i| {
-            let mut text = "Dropping files:\n".to_owned();
-            for file in &i.raw.hovered_files {
-                if let Some(path) = &file.path {
-                    write!(text, "\n{}", path.display()).ok();
-                } else if !file.mime.is_empty() {
-                    write!(text, "\n{}", file.mime).ok();
-                } else {
-                    text += "\n???";
-                }
+            if let Some(file_response) = file_dialog
+                .as_mut()
+                .and_then(|task| block_on(poll_once(task)))
+            {
+                state.picked_path = file_response.map(|path| path.path().display().to_string());
+                *file_dialog = None;
             }
-            text
+
+            if ui.button("Open file…").clicked() {
+                *file_dialog = Some(
+                    AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()),
+                );
+            }
+
+            if let Some(picked_path) = &state.picked_path {
+                ui.horizontal(|ui| {
+                    ui.label("Picked file:");
+                    ui.monospace(picked_path);
+                });
+            }
+
+            // Show dropped files (if any):
+            if !state.dropped_files.is_empty() {
+                ui.group(|ui| {
+                    ui.label("Dropped files:");
+
+                    for file in &state.dropped_files {
+                        let mut info = if let Some(path) = &file.path {
+                            path.display().to_string()
+                        } else if !file.name.is_empty() {
+                            file.name.clone()
+                        } else {
+                            "???".to_owned()
+                        };
+
+                        let mut additional_info = vec![];
+                        if !file.mime.is_empty() {
+                            additional_info.push(format!("type: {}", file.mime));
+                        }
+                        if let Some(bytes) = &file.bytes {
+                            additional_info.push(format!("{} bytes", bytes.len()));
+                        }
+                        if !additional_info.is_empty() {
+                            info += &format!(" ({})", additional_info.join(", "));
+                        }
+
+                        ui.label(info);
+                    }
+                });
+            }
         });
 
-        let painter =
-            ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+        preview_files_being_dropped(ctx);
 
-        let screen_rect = ctx.screen_rect();
-        painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
-        painter.text(
-            screen_rect.center(),
-            Align2::CENTER_CENTER,
-            text,
-            TextStyle::Heading.resolve(&ctx.style()),
-            Color32::WHITE,
-        );
+        // Collect dropped files:
+        ctx.input(|i| {
+            if !i.raw.dropped_files.is_empty() {
+                state.dropped_files.clone_from(&i.raw.dropped_files);
+            }
+        });
+
+        ctx.input(|i| {
+            if i.raw.modifiers.ctrl {
+                info!("ctrl pressed");
+            }
+        })
+    }
+
+    fn preview_files_being_dropped(ctx: &egui::Context) {
+        use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+        use std::fmt::Write as _;
+
+        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+            let text = ctx.input(|i| {
+                let mut text = "Dropping files:\n".to_owned();
+                for file in &i.raw.hovered_files {
+                    if let Some(path) = &file.path {
+                        write!(text, "\n{}", path.display()).ok();
+                    } else if !file.mime.is_empty() {
+                        write!(text, "\n{}", file.mime).ok();
+                    } else {
+                        text += "\n???";
+                    }
+                }
+                text
+            });
+
+            let painter =
+                ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+            let screen_rect = ctx.screen_rect();
+            painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
+            painter.text(
+                screen_rect.center(),
+                Align2::CENTER_CENTER,
+                text,
+                TextStyle::Heading.resolve(&ctx.style()),
+                Color32::WHITE,
+            );
+        }
     }
 }
 
-// do nothing for ios / android / wasm :(
+// do nothing for wasm/ios/android :(
 #[cfg(any(target_os = "ios", target_os = "android", target_arch = "wasm32"))]
-fn main() {}
+mod foo {
+    pub fn ui_system() {}
+}

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -1,5 +1,10 @@
-use bevy::prelude::*;
-use bevy_egui::{EguiContextPass, EguiPlugin};
+#![cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
+
+use bevy::{
+    prelude::*,
+    tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
+};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
 
 fn main() {
     App::new()
@@ -7,141 +12,125 @@ fn main() {
         .add_plugins(EguiPlugin {
             enable_multipass_for_primary_context: true,
         })
-        .add_systems(EguiContextPass, foo::ui_system)
+        .add_systems(EguiContextPass, ui_system)
         .run();
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-mod foo {
-    use bevy::{
-        prelude::*,
-        tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
-    };
-    use bevy_egui::{egui, EguiContexts};
-
-    #[derive(Default)]
-    pub struct MyState {
-        dropped_files: Vec<egui::DroppedFile>,
-        picked_path: Option<String>,
-    }
-
-    type DialogResponse = Option<rfd::FileHandle>;
-
-    // much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
-    pub fn ui_system(
-        mut contexts: EguiContexts,
-        mut state: Local<MyState>,
-        mut file_dialog: Local<Option<Task<DialogResponse>>>,
-    ) {
-        let ctx = contexts.ctx_mut();
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.label("Drag-and-drop files onto the window!");
-
-            if let Some(file_response) = file_dialog
-                .as_mut()
-                .and_then(|task| block_on(poll_once(task)))
-            {
-                state.picked_path = file_response.map(|path| path.path().display().to_string());
-                *file_dialog = None;
-            }
-
-            if ui.button("Open file…").clicked() {
-                *file_dialog = Some(
-                    AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()),
-                );
-            }
-
-            if let Some(picked_path) = &state.picked_path {
-                ui.horizontal(|ui| {
-                    ui.label("Picked file:");
-                    ui.monospace(picked_path);
-                });
-            }
-
-            // Show dropped files (if any):
-            if !state.dropped_files.is_empty() {
-                ui.group(|ui| {
-                    ui.label("Dropped files:");
-
-                    for file in &state.dropped_files {
-                        let mut info = if let Some(path) = &file.path {
-                            path.display().to_string()
-                        } else if !file.name.is_empty() {
-                            file.name.clone()
-                        } else {
-                            "???".to_owned()
-                        };
-
-                        let mut additional_info = vec![];
-                        if !file.mime.is_empty() {
-                            additional_info.push(format!("type: {}", file.mime));
-                        }
-                        if let Some(bytes) = &file.bytes {
-                            additional_info.push(format!("{} bytes", bytes.len()));
-                        }
-                        if !additional_info.is_empty() {
-                            info += &format!(" ({})", additional_info.join(", "));
-                        }
-
-                        ui.label(info);
-                    }
-                });
-            }
-        });
-
-        preview_files_being_dropped(ctx);
-
-        // Collect dropped files:
-        ctx.input(|i| {
-            if !i.raw.dropped_files.is_empty() {
-                state.dropped_files.clone_from(&i.raw.dropped_files);
-            }
-        });
-
-        ctx.input(|i| {
-            if i.raw.modifiers.ctrl {
-                info!("ctrl pressed");
-            }
-        })
-    }
-
-    fn preview_files_being_dropped(ctx: &egui::Context) {
-        use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
-        use std::fmt::Write as _;
-
-        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
-            let text = ctx.input(|i| {
-                let mut text = "Dropping files:\n".to_owned();
-                for file in &i.raw.hovered_files {
-                    if let Some(path) = &file.path {
-                        write!(text, "\n{}", path.display()).ok();
-                    } else if !file.mime.is_empty() {
-                        write!(text, "\n{}", file.mime).ok();
-                    } else {
-                        text += "\n???";
-                    }
-                }
-                text
-            });
-
-            let painter =
-                ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
-
-            let screen_rect = ctx.screen_rect();
-            painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
-            painter.text(
-                screen_rect.center(),
-                Align2::CENTER_CENTER,
-                text,
-                TextStyle::Heading.resolve(&ctx.style()),
-                Color32::WHITE,
-            );
-        }
-    }
+#[derive(Default)]
+pub struct MyState {
+    dropped_files: Vec<egui::DroppedFile>,
+    picked_path: Option<String>,
 }
 
-// do nothing for wasm/ios/android :(
-#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
-mod foo {
-    pub fn ui_system() {}
+type DialogResponse = Option<rfd::FileHandle>;
+
+// much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
+pub fn ui_system(
+    mut contexts: EguiContexts,
+    mut state: Local<MyState>,
+    mut file_dialog: Local<Option<Task<DialogResponse>>>,
+) {
+    let ctx = contexts.ctx_mut();
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.label("Drag-and-drop files onto the window!");
+
+        if let Some(file_response) = file_dialog
+            .as_mut()
+            .and_then(|task| block_on(poll_once(task)))
+        {
+            state.picked_path = file_response.map(|path| path.path().display().to_string());
+            *file_dialog = None;
+        }
+
+        if ui.button("Open file…").clicked() {
+            *file_dialog =
+                Some(AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()));
+        }
+
+        if let Some(picked_path) = &state.picked_path {
+            ui.horizontal(|ui| {
+                ui.label("Picked file:");
+                ui.monospace(picked_path);
+            });
+        }
+
+        // Show dropped files (if any):
+        if !state.dropped_files.is_empty() {
+            ui.group(|ui| {
+                ui.label("Dropped files:");
+
+                for file in &state.dropped_files {
+                    let mut info = if let Some(path) = &file.path {
+                        path.display().to_string()
+                    } else if !file.name.is_empty() {
+                        file.name.clone()
+                    } else {
+                        "???".to_owned()
+                    };
+
+                    let mut additional_info = vec![];
+                    if !file.mime.is_empty() {
+                        additional_info.push(format!("type: {}", file.mime));
+                    }
+                    if let Some(bytes) = &file.bytes {
+                        additional_info.push(format!("{} bytes", bytes.len()));
+                    }
+                    if !additional_info.is_empty() {
+                        info += &format!(" ({})", additional_info.join(", "));
+                    }
+
+                    ui.label(info);
+                }
+            });
+        }
+    });
+
+    preview_files_being_dropped(ctx);
+
+    // Collect dropped files:
+    ctx.input(|i| {
+        if !i.raw.dropped_files.is_empty() {
+            state.dropped_files.clone_from(&i.raw.dropped_files);
+        }
+    });
+
+    ctx.input(|i| {
+        if i.raw.modifiers.ctrl {
+            info!("ctrl pressed");
+        }
+    })
+}
+
+fn preview_files_being_dropped(ctx: &egui::Context) {
+    use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+    use std::fmt::Write as _;
+
+    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+        let text = ctx.input(|i| {
+            let mut text = "Dropping files:\n".to_owned();
+            for file in &i.raw.hovered_files {
+                if let Some(path) = &file.path {
+                    write!(text, "\n{}", path.display()).ok();
+                } else if !file.mime.is_empty() {
+                    write!(text, "\n{}", file.mime).ok();
+                } else {
+                    text += "\n???";
+                }
+            }
+            text
+        });
+
+        let painter =
+            ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+        let screen_rect = ctx.screen_rect();
+        painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
+        painter.text(
+            screen_rect.center(),
+            Align2::CENTER_CENTER,
+            text,
+            TextStyle::Heading.resolve(&ctx.style()),
+            Color32::WHITE,
+        );
+    }
 }

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -1,8 +1,5 @@
-use bevy::{
-    prelude::*,
-    tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
-};
-use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
+use bevy::prelude::*;
+use bevy_egui::{EguiContextPass, EguiPlugin};
 
 fn main() {
     App::new()
@@ -10,125 +7,141 @@ fn main() {
         .add_plugins(EguiPlugin {
             enable_multipass_for_primary_context: true,
         })
-        .add_systems(EguiContextPass, ui_system)
+        .add_systems(EguiContextPass, foo::ui_system)
         .run();
 }
 
-#[derive(Default)]
-struct MyState {
-    dropped_files: Vec<egui::DroppedFile>,
-    picked_path: Option<String>,
-}
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+mod foo {
+    use bevy::{
+        prelude::*,
+        tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
+    };
+    use bevy_egui::{egui, EguiContexts};
 
-type DialogResponse = Option<rfd::FileHandle>;
+    #[derive(Default)]
+    pub struct MyState {
+        dropped_files: Vec<egui::DroppedFile>,
+        picked_path: Option<String>,
+    }
 
-// much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
-fn ui_system(
-    mut contexts: EguiContexts,
-    mut state: Local<MyState>,
-    mut file_dialog: Local<Option<Task<DialogResponse>>>,
-) {
-    let ctx = contexts.ctx_mut();
-    egui::CentralPanel::default().show(ctx, |ui| {
-        ui.label("Drag-and-drop files onto the window!");
+    type DialogResponse = Option<rfd::FileHandle>;
 
-        if let Some(file_response) = file_dialog
-            .as_mut()
-            .and_then(|task| block_on(poll_once(task)))
-        {
-            state.picked_path = file_response.map(|path| path.path().display().to_string());
-            *file_dialog = None;
-        }
+    // much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
+    pub fn ui_system(
+        mut contexts: EguiContexts,
+        mut state: Local<MyState>,
+        mut file_dialog: Local<Option<Task<DialogResponse>>>,
+    ) {
+        let ctx = contexts.ctx_mut();
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label("Drag-and-drop files onto the window!");
 
-        if ui.button("Open file…").clicked() {
-            *file_dialog =
-                Some(AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()));
-        }
-
-        if let Some(picked_path) = &state.picked_path {
-            ui.horizontal(|ui| {
-                ui.label("Picked file:");
-                ui.monospace(picked_path);
-            });
-        }
-
-        // Show dropped files (if any):
-        if !state.dropped_files.is_empty() {
-            ui.group(|ui| {
-                ui.label("Dropped files:");
-
-                for file in &state.dropped_files {
-                    let mut info = if let Some(path) = &file.path {
-                        path.display().to_string()
-                    } else if !file.name.is_empty() {
-                        file.name.clone()
-                    } else {
-                        "???".to_owned()
-                    };
-
-                    let mut additional_info = vec![];
-                    if !file.mime.is_empty() {
-                        additional_info.push(format!("type: {}", file.mime));
-                    }
-                    if let Some(bytes) = &file.bytes {
-                        additional_info.push(format!("{} bytes", bytes.len()));
-                    }
-                    if !additional_info.is_empty() {
-                        info += &format!(" ({})", additional_info.join(", "));
-                    }
-
-                    ui.label(info);
-                }
-            });
-        }
-    });
-
-    preview_files_being_dropped(ctx);
-
-    // Collect dropped files:
-    ctx.input(|i| {
-        if !i.raw.dropped_files.is_empty() {
-            state.dropped_files.clone_from(&i.raw.dropped_files);
-        }
-    });
-
-    ctx.input(|i| {
-        if i.raw.modifiers.ctrl {
-            info!("ctrl pressed");
-        }
-    })
-}
-
-fn preview_files_being_dropped(ctx: &egui::Context) {
-    use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
-    use std::fmt::Write as _;
-
-    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
-        let text = ctx.input(|i| {
-            let mut text = "Dropping files:\n".to_owned();
-            for file in &i.raw.hovered_files {
-                if let Some(path) = &file.path {
-                    write!(text, "\n{}", path.display()).ok();
-                } else if !file.mime.is_empty() {
-                    write!(text, "\n{}", file.mime).ok();
-                } else {
-                    text += "\n???";
-                }
+            if let Some(file_response) = file_dialog
+                .as_mut()
+                .and_then(|task| block_on(poll_once(task)))
+            {
+                state.picked_path = file_response.map(|path| path.path().display().to_string());
+                *file_dialog = None;
             }
-            text
+
+            if ui.button("Open file…").clicked() {
+                *file_dialog = Some(
+                    AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()),
+                );
+            }
+
+            if let Some(picked_path) = &state.picked_path {
+                ui.horizontal(|ui| {
+                    ui.label("Picked file:");
+                    ui.monospace(picked_path);
+                });
+            }
+
+            // Show dropped files (if any):
+            if !state.dropped_files.is_empty() {
+                ui.group(|ui| {
+                    ui.label("Dropped files:");
+
+                    for file in &state.dropped_files {
+                        let mut info = if let Some(path) = &file.path {
+                            path.display().to_string()
+                        } else if !file.name.is_empty() {
+                            file.name.clone()
+                        } else {
+                            "???".to_owned()
+                        };
+
+                        let mut additional_info = vec![];
+                        if !file.mime.is_empty() {
+                            additional_info.push(format!("type: {}", file.mime));
+                        }
+                        if let Some(bytes) = &file.bytes {
+                            additional_info.push(format!("{} bytes", bytes.len()));
+                        }
+                        if !additional_info.is_empty() {
+                            info += &format!(" ({})", additional_info.join(", "));
+                        }
+
+                        ui.label(info);
+                    }
+                });
+            }
         });
 
-        let painter =
-            ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+        preview_files_being_dropped(ctx);
 
-        let screen_rect = ctx.screen_rect();
-        painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
-        painter.text(
-            screen_rect.center(),
-            Align2::CENTER_CENTER,
-            text,
-            TextStyle::Heading.resolve(&ctx.style()),
-            Color32::WHITE,
-        );
+        // Collect dropped files:
+        ctx.input(|i| {
+            if !i.raw.dropped_files.is_empty() {
+                state.dropped_files.clone_from(&i.raw.dropped_files);
+            }
+        });
+
+        ctx.input(|i| {
+            if i.raw.modifiers.ctrl {
+                info!("ctrl pressed");
+            }
+        })
     }
+
+    fn preview_files_being_dropped(ctx: &egui::Context) {
+        use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+        use std::fmt::Write as _;
+
+        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+            let text = ctx.input(|i| {
+                let mut text = "Dropping files:\n".to_owned();
+                for file in &i.raw.hovered_files {
+                    if let Some(path) = &file.path {
+                        write!(text, "\n{}", path.display()).ok();
+                    } else if !file.mime.is_empty() {
+                        write!(text, "\n{}", file.mime).ok();
+                    } else {
+                        text += "\n???";
+                    }
+                }
+                text
+            });
+
+            let painter =
+                ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+            let screen_rect = ctx.screen_rect();
+            painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
+            painter.text(
+                screen_rect.center(),
+                Align2::CENTER_CENTER,
+                text,
+                TextStyle::Heading.resolve(&ctx.style()),
+                Color32::WHITE,
+            );
+        }
+    }
+}
+
+// do nothing for wasm/ios/android :(
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+mod foo {
+    pub fn ui_system() {}
 }

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_egui::{EguiContextPass, EguiPlugin};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
 
 fn main() {
     App::new()
@@ -7,141 +7,106 @@ fn main() {
         .add_plugins(EguiPlugin {
             enable_multipass_for_primary_context: true,
         })
-        .add_systems(EguiContextPass, foo::ui_system)
+        .add_systems(EguiContextPass, ui_system)
         .run();
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android", target_arch = "wasm32")))]
-mod foo {
-    use bevy::{
-        prelude::*,
-        tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
-    };
-    use bevy_egui::{egui, EguiContexts};
-
-    #[derive(Default)]
-    pub struct MyState {
-        dropped_files: Vec<egui::DroppedFile>,
-        picked_path: Option<String>,
-    }
-
-    type DialogResponse = Option<rfd::FileHandle>;
-
-    // much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
-    pub fn ui_system(
-        mut contexts: EguiContexts,
-        mut state: Local<MyState>,
-        mut file_dialog: Local<Option<Task<DialogResponse>>>,
-    ) {
-        let ctx = contexts.ctx_mut();
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.label("Drag-and-drop files onto the window!");
-
-            if let Some(file_response) = file_dialog
-                .as_mut()
-                .and_then(|task| block_on(poll_once(task)))
-            {
-                state.picked_path = file_response.map(|path| path.path().display().to_string());
-                *file_dialog = None;
-            }
-
-            if ui.button("Open file…").clicked() {
-                *file_dialog = Some(
-                    AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()),
-                );
-            }
-
-            if let Some(picked_path) = &state.picked_path {
-                ui.horizontal(|ui| {
-                    ui.label("Picked file:");
-                    ui.monospace(picked_path);
-                });
-            }
-
-            // Show dropped files (if any):
-            if !state.dropped_files.is_empty() {
-                ui.group(|ui| {
-                    ui.label("Dropped files:");
-
-                    for file in &state.dropped_files {
-                        let mut info = if let Some(path) = &file.path {
-                            path.display().to_string()
-                        } else if !file.name.is_empty() {
-                            file.name.clone()
-                        } else {
-                            "???".to_owned()
-                        };
-
-                        let mut additional_info = vec![];
-                        if !file.mime.is_empty() {
-                            additional_info.push(format!("type: {}", file.mime));
-                        }
-                        if let Some(bytes) = &file.bytes {
-                            additional_info.push(format!("{} bytes", bytes.len()));
-                        }
-                        if !additional_info.is_empty() {
-                            info += &format!(" ({})", additional_info.join(", "));
-                        }
-
-                        ui.label(info);
-                    }
-                });
-            }
-        });
-
-        preview_files_being_dropped(ctx);
-
-        // Collect dropped files:
-        ctx.input(|i| {
-            if !i.raw.dropped_files.is_empty() {
-                state.dropped_files.clone_from(&i.raw.dropped_files);
-            }
-        });
-
-        ctx.input(|i| {
-            if i.raw.modifiers.ctrl {
-                info!("ctrl pressed");
-            }
-        })
-    }
-
-    fn preview_files_being_dropped(ctx: &egui::Context) {
-        use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
-        use std::fmt::Write as _;
-
-        if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
-            let text = ctx.input(|i| {
-                let mut text = "Dropping files:\n".to_owned();
-                for file in &i.raw.hovered_files {
-                    if let Some(path) = &file.path {
-                        write!(text, "\n{}", path.display()).ok();
-                    } else if !file.mime.is_empty() {
-                        write!(text, "\n{}", file.mime).ok();
-                    } else {
-                        text += "\n???";
-                    }
-                }
-                text
-            });
-
-            let painter =
-                ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
-
-            let screen_rect = ctx.screen_rect();
-            painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
-            painter.text(
-                screen_rect.center(),
-                Align2::CENTER_CENTER,
-                text,
-                TextStyle::Heading.resolve(&ctx.style()),
-                Color32::WHITE,
-            );
-        }
-    }
+#[derive(Default)]
+pub struct MyState {
+    dropped_files: Vec<egui::DroppedFile>,
+    picked_path: Option<String>,
 }
 
-// do nothing for wasm/ios/android :(
-#[cfg(any(target_os = "ios", target_os = "android", target_arch = "wasm32"))]
-mod foo {
-    pub fn ui_system() {}
+// much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
+pub fn ui_system(mut contexts: EguiContexts, mut state: Local<MyState>) {
+    let ctx = contexts.ctx_mut();
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.label("Drag-and-drop files onto the window!");
+
+        if let Some(picked_path) = &state.picked_path {
+            ui.horizontal(|ui| {
+                ui.label("Picked file:");
+                ui.monospace(picked_path);
+            });
+        }
+
+        // Show dropped files (if any):
+        if !state.dropped_files.is_empty() {
+            ui.group(|ui| {
+                ui.label("Dropped files:");
+
+                for file in &state.dropped_files {
+                    let mut info = if let Some(path) = &file.path {
+                        path.display().to_string()
+                    } else if !file.name.is_empty() {
+                        file.name.clone()
+                    } else {
+                        "???".to_owned()
+                    };
+
+                    let mut additional_info = vec![];
+                    if !file.mime.is_empty() {
+                        additional_info.push(format!("type: {}", file.mime));
+                    }
+                    if let Some(bytes) = &file.bytes {
+                        additional_info.push(format!("{} bytes", bytes.len()));
+                    }
+                    if !additional_info.is_empty() {
+                        info += &format!(" ({})", additional_info.join(", "));
+                    }
+
+                    ui.label(info);
+                }
+            });
+        }
+    });
+
+    preview_files_being_dropped(ctx);
+
+    // Collect dropped files:
+    ctx.input(|i| {
+        if !i.raw.dropped_files.is_empty() {
+            state.dropped_files.clone_from(&i.raw.dropped_files);
+        }
+    });
+
+    ctx.input(|i| {
+        if i.raw.modifiers.ctrl {
+            info!("ctrl pressed");
+        }
+    })
+}
+
+fn preview_files_being_dropped(ctx: &egui::Context) {
+    use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+    use std::fmt::Write as _;
+
+    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+        let text = ctx.input(|i| {
+            let mut text = "Dropping files:\n".to_owned();
+            for file in &i.raw.hovered_files {
+                if let Some(path) = &file.path {
+                    write!(text, "\n{}", path.display()).ok();
+                } else if !file.mime.is_empty() {
+                    write!(text, "\n{}", file.mime).ok();
+                } else {
+                    text += "\n???";
+                }
+            }
+            text
+        });
+
+        let painter =
+            ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+        let screen_rect = ctx.screen_rect();
+        painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
+        painter.text(
+            screen_rect.center(),
+            Align2::CENTER_CENTER,
+            text,
+            TextStyle::Heading.resolve(&ctx.style()),
+            Color32::WHITE,
+        );
+    }
 }

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -134,3 +134,7 @@ fn preview_files_being_dropped(ctx: &egui::Context) {
         );
     }
 }
+
+// do nothing for ios / android / wasm :(
+#[cfg(any(target_os = "ios", target_os = "android", target_arch = "wasm32"))]
+fn main() {}

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -1,0 +1,134 @@
+use bevy::{
+    prelude::*,
+    tasks::{block_on, poll_once, AsyncComputeTaskPool, Task},
+};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
+        .add_systems(EguiContextPass, ui_system)
+        .run();
+}
+
+#[derive(Default)]
+struct MyState {
+    dropped_files: Vec<egui::DroppedFile>,
+    picked_path: Option<String>,
+}
+
+type DialogResponse = Option<rfd::FileHandle>;
+
+// much of this ui is taken from https://github.com/emilk/egui/blob/c6bd30642a78d5ff244b064642c053f62967ef1b/examples/file_dialog/src/main.rs
+fn ui_system(
+    mut contexts: EguiContexts,
+    mut state: Local<MyState>,
+    mut file_dialog: Local<Option<Task<DialogResponse>>>,
+) {
+    let ctx = contexts.ctx_mut();
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.label("Drag-and-drop files onto the window!");
+
+        if let Some(file_response) = file_dialog
+            .as_mut()
+            .and_then(|task| block_on(poll_once(task)))
+        {
+            state.picked_path = file_response.map(|path| path.path().display().to_string());
+            *file_dialog = None;
+        }
+
+        if ui.button("Open file…").clicked() {
+            *file_dialog =
+                Some(AsyncComputeTaskPool::get().spawn(rfd::AsyncFileDialog::new().pick_file()));
+        }
+
+        if let Some(picked_path) = &state.picked_path {
+            ui.horizontal(|ui| {
+                ui.label("Picked file:");
+                ui.monospace(picked_path);
+            });
+        }
+
+        // Show dropped files (if any):
+        if !state.dropped_files.is_empty() {
+            ui.group(|ui| {
+                ui.label("Dropped files:");
+
+                for file in &state.dropped_files {
+                    let mut info = if let Some(path) = &file.path {
+                        path.display().to_string()
+                    } else if !file.name.is_empty() {
+                        file.name.clone()
+                    } else {
+                        "???".to_owned()
+                    };
+
+                    let mut additional_info = vec![];
+                    if !file.mime.is_empty() {
+                        additional_info.push(format!("type: {}", file.mime));
+                    }
+                    if let Some(bytes) = &file.bytes {
+                        additional_info.push(format!("{} bytes", bytes.len()));
+                    }
+                    if !additional_info.is_empty() {
+                        info += &format!(" ({})", additional_info.join(", "));
+                    }
+
+                    ui.label(info);
+                }
+            });
+        }
+    });
+
+    preview_files_being_dropped(ctx);
+
+    // Collect dropped files:
+    ctx.input(|i| {
+        if !i.raw.dropped_files.is_empty() {
+            state.dropped_files.clone_from(&i.raw.dropped_files);
+        }
+    });
+
+    ctx.input(|i| {
+        if i.raw.modifiers.ctrl {
+            info!("ctrl pressed");
+        }
+    })
+}
+
+fn preview_files_being_dropped(ctx: &egui::Context) {
+    use egui::{Align2, Color32, Id, LayerId, Order, TextStyle};
+    use std::fmt::Write as _;
+
+    if !ctx.input(|i| i.raw.hovered_files.is_empty()) {
+        let text = ctx.input(|i| {
+            let mut text = "Dropping files:\n".to_owned();
+            for file in &i.raw.hovered_files {
+                if let Some(path) = &file.path {
+                    write!(text, "\n{}", path.display()).ok();
+                } else if !file.mime.is_empty() {
+                    write!(text, "\n{}", file.mime).ok();
+                } else {
+                    text += "\n???";
+                }
+            }
+            text
+        });
+
+        let painter =
+            ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+
+        let screen_rect = ctx.screen_rect();
+        painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(192));
+        painter.text(
+            screen_rect.center(),
+            Align2::CENTER_CENTER,
+            text,
+            TextStyle::Heading.resolve(&ctx.style()),
+            Color32::WHITE,
+        );
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,7 +13,7 @@ use bevy_input::{
 };
 use bevy_log as log;
 use bevy_time::{Real, Time};
-use bevy_window::{CursorMoved, Ime, Window};
+use bevy_window::{CursorMoved, FileDragAndDrop, Ime, Window};
 use egui::Modifiers;
 
 /// Cached pointer position, used to populate [`egui::Event::PointerButton`] events.
@@ -44,6 +44,15 @@ pub struct EguiInputEvent {
     pub context: Entity,
     /// Wrapped event.
     pub event: egui::Event,
+}
+
+#[derive(Event)]
+/// Wraps [`bevy::FileDragAndDrop`](bevy_window::FileDragAndDrop) events emitted by [`crate::EguiInputSet`] systems.
+pub struct EguiFileDragAndDropEvent {
+    /// Context to pass an event to.
+    pub context: Entity,
+    /// Wrapped event.
+    pub event: FileDragAndDrop,
 }
 
 #[derive(Resource)]
@@ -551,6 +560,63 @@ pub fn write_ime_events_system(
     }
 }
 
+/// Reads [`FileDragAndDrop`] events and wraps them into [`EguiFileDragAndDropEvent`], can redirect events to [`FocusedNonWindowEguiContext`].
+pub fn write_file_dnd_events_system(
+    focused_non_window_egui_context: Option<Res<FocusedNonWindowEguiContext>>,
+    mut dnd_reader: EventReader<FileDragAndDrop>,
+    mut egui_file_dnd_event_writer: EventWriter<EguiFileDragAndDropEvent>,
+    egui_contexts: Query<&EguiContextSettings, With<EguiContext>>,
+) {
+    for event in dnd_reader.read() {
+        let window = match &event {
+            FileDragAndDrop::DroppedFile { window, .. }
+            | FileDragAndDrop::HoveredFile { window, .. }
+            | FileDragAndDrop::HoveredFileCanceled { window } => *window,
+        };
+        let context = focused_non_window_egui_context
+            .as_deref()
+            .map_or(window, |context| context.0);
+
+        let Some(context_settings) = egui_contexts.get_some(context) else {
+            continue;
+        };
+
+        if !context_settings
+            .input_system_settings
+            .run_write_file_dnd_events_system
+        {
+            continue;
+        }
+
+        match event {
+            FileDragAndDrop::DroppedFile { window, path_buf } => {
+                egui_file_dnd_event_writer.write(EguiFileDragAndDropEvent {
+                    context,
+                    event: FileDragAndDrop::DroppedFile {
+                        window: *window,
+                        path_buf: path_buf.clone(),
+                    },
+                });
+            }
+            FileDragAndDrop::HoveredFile { window, path_buf } => {
+                egui_file_dnd_event_writer.write(EguiFileDragAndDropEvent {
+                    context,
+                    event: FileDragAndDrop::HoveredFile {
+                        window: *window,
+                        path_buf: path_buf.clone(),
+                    },
+                });
+            }
+            FileDragAndDrop::HoveredFileCanceled { window } => {
+                egui_file_dnd_event_writer.write(EguiFileDragAndDropEvent {
+                    context,
+                    event: FileDragAndDrop::HoveredFileCanceled { window: *window },
+                });
+            }
+        }
+    }
+}
+
 /// Reads [`TouchInput`] events and wraps them into [`EguiInputEvent`].
 pub fn write_window_touch_events_system(
     mut commands: Commands,
@@ -807,6 +873,62 @@ pub fn write_egui_input_system(
             |context| context.0 == entity,
         );
         egui_input.modifiers = modifier_keys_state.to_egui_modifiers();
+        egui_input.time = Some(time.elapsed_secs_f64());
+    }
+}
+
+/// Reads [`EguiFileDragAndDropEvent`] events and feeds them to Egui.
+pub fn write_egui_file_dnd_system(
+    focused_non_window_egui_context: Option<Res<FocusedNonWindowEguiContext>>,
+    mut egui_file_dnd_event_reader: EventReader<EguiFileDragAndDropEvent>,
+    mut egui_contexts: Query<(Entity, &mut EguiInput, Option<&Window>)>,
+    time: Res<Time<Real>>,
+) {
+    for EguiFileDragAndDropEvent { context, event } in egui_file_dnd_event_reader.read() {
+        #[cfg(feature = "log_file_dnd_events")]
+        log::warn!("{context:?}: {event:?}");
+
+        let (_, mut egui_input, _) = match egui_contexts.get_mut(*context) {
+            Ok(egui_input) => egui_input,
+            Err(err) => {
+                log::error!(
+                    "Failed to get an Egui context ({context:?}) for an event ({event:?}): {err:?}"
+                );
+                continue;
+            }
+        };
+
+        match event {
+            FileDragAndDrop::DroppedFile {
+                window: _,
+                path_buf,
+            } => {
+                egui_input.hovered_files.clear();
+                egui_input.dropped_files.push(egui::DroppedFile {
+                    path: Some(path_buf.clone()),
+                    ..Default::default()
+                });
+            }
+            FileDragAndDrop::HoveredFile {
+                window: _,
+                path_buf,
+            } => {
+                egui_input.hovered_files.push(egui::HoveredFile {
+                    path: Some(path_buf.clone()),
+                    ..Default::default()
+                });
+            }
+            FileDragAndDrop::HoveredFileCanceled { window: _ } => {
+                egui_input.hovered_files.clear();
+            }
+        }
+    }
+
+    for (entity, mut egui_input, window) in egui_contexts.iter_mut() {
+        egui_input.focused = focused_non_window_egui_context.as_deref().map_or_else(
+            || window.is_some_and(|window| window.focused),
+            |context| context.0 == entity,
+        );
         egui_input.time = Some(time.elapsed_secs_f64());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -842,11 +842,12 @@ fn write_touch_event(
     }
 }
 
-/// Reads [`EguiInputEvent`] events and feeds them to Egui.
+/// Reads both [`EguiFileDragAndDropEvent`] and [`EguiInputEvent`] events and feeds them to Egui.
 pub fn write_egui_input_system(
     focused_non_window_egui_context: Option<Res<FocusedNonWindowEguiContext>>,
     modifier_keys_state: Res<ModifierKeysState>,
     mut egui_input_event_reader: EventReader<EguiInputEvent>,
+    mut egui_file_dnd_event_reader: EventReader<EguiFileDragAndDropEvent>,
     mut egui_contexts: Query<(Entity, &mut EguiInput, Option<&Window>)>,
     time: Res<Time<Real>>,
 ) {
@@ -867,23 +868,6 @@ pub fn write_egui_input_system(
         egui_input.events.push(event.clone());
     }
 
-    for (entity, mut egui_input, window) in egui_contexts.iter_mut() {
-        egui_input.focused = focused_non_window_egui_context.as_deref().map_or_else(
-            || window.is_some_and(|window| window.focused),
-            |context| context.0 == entity,
-        );
-        egui_input.modifiers = modifier_keys_state.to_egui_modifiers();
-        egui_input.time = Some(time.elapsed_secs_f64());
-    }
-}
-
-/// Reads [`EguiFileDragAndDropEvent`] events and feeds them to Egui.
-pub fn write_egui_file_dnd_system(
-    focused_non_window_egui_context: Option<Res<FocusedNonWindowEguiContext>>,
-    mut egui_file_dnd_event_reader: EventReader<EguiFileDragAndDropEvent>,
-    mut egui_contexts: Query<(Entity, &mut EguiInput, Option<&Window>)>,
-    time: Res<Time<Real>>,
-) {
     for EguiFileDragAndDropEvent { context, event } in egui_file_dnd_event_reader.read() {
         #[cfg(feature = "log_file_dnd_events")]
         log::warn!("{context:?}: {event:?}");
@@ -929,6 +913,7 @@ pub fn write_egui_file_dnd_system(
             || window.is_some_and(|window| window.focused),
             |context| context.0 == entity,
         );
+        egui_input.modifiers = modifier_keys_state.to_egui_modifiers();
         egui_input.time = Some(time.elapsed_secs_f64());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,6 +442,8 @@ pub struct EguiInputSystemSettings {
     pub run_write_keyboard_input_events_system: bool,
     /// Controls running of the [`write_ime_events_system`] system.
     pub run_write_ime_events_system: bool,
+    /// Controls running of the [`write_file_dnd_events_system`] system.
+    pub run_write_file_dnd_events_system: bool,
     /// Controls running of the [`write_text_agent_channel_events_system`] system.
     #[cfg(target_arch = "wasm32")]
     pub run_write_text_agent_channel_events_system: bool,
@@ -462,6 +464,7 @@ impl Default for EguiInputSystemSettings {
             run_write_non_window_touch_events_system: true,
             run_write_keyboard_input_events_system: true,
             run_write_ime_events_system: true,
+            run_write_file_dnd_events_system: true,
             #[cfg(target_arch = "wasm32")]
             run_write_text_agent_channel_events_system: true,
             #[cfg(all(feature = "manage_clipboard", target_arch = "wasm32"))]
@@ -965,6 +968,7 @@ impl Plugin for EguiPlugin {
         app.init_resource::<ModifierKeysState>();
         app.init_resource::<EguiWantsInput>();
         app.add_event::<EguiInputEvent>();
+        app.add_event::<EguiFileDragAndDropEvent>();
 
         if self.enable_multipass_for_primary_context {
             app.insert_resource(EnableMultipassForPrimaryContext);
@@ -1092,10 +1096,14 @@ impl Plugin for EguiPlugin {
                     })),
                     write_ime_events_system
                         .run_if(input_system_is_enabled(|s| s.run_write_ime_events_system)),
+                    write_file_dnd_events_system.run_if(input_system_is_enabled(|s| {
+                        s.run_write_file_dnd_events_system
+                    })),
                 )
                     .in_set(EguiInputSet::ReadBevyEvents),
                 (
                     write_egui_input_system,
+                    write_egui_file_dnd_system,
                     absorb_bevy_input_system.run_if(|settings: Res<EguiGlobalSettings>| {
                         settings.enable_absorb_bevy_input_system
                     }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,7 +1103,6 @@ impl Plugin for EguiPlugin {
                     .in_set(EguiInputSet::ReadBevyEvents),
                 (
                     write_egui_input_system,
-                    write_egui_file_dnd_system,
                     absorb_bevy_input_system.run_if(|settings: Res<EguiGlobalSettings>| {
                         settings.enable_absorb_bevy_input_system
                     }),


### PR DESCRIPTION
 ## Description
 
This PR adds functionality to pass `bevy_window::FileDragAndDrop` events down to egui. Additionally adds a bevy-ified version of the [egui file_dialog example](https://github.com/emilk/egui/blob/master/examples/file_dialog/src/main.rs). 

 ## Changes:
 
* Added a `log_file_dnd_events` feature similar in functionality to the `log_input_events` feature
* Added an example of bevy events going through to egui for files being dragged and dropped onto the window
* Added new bevy systems, event, and setting for controlling event passthrough

## Why this is needed:

Currently when using `bevy_egui` any files that get dragged and dropped (or hovered) onto the window can only be read from directly via bevy. With this it allows passing down into the egui context for usage there.

## Limitations:

I don't believe that there is a concise way to handle the location of a file drop / hover, only that it exists.

This is to be fixed with the release of `winit 0.31` afaik and should eventually be covered.

