### PR TITLE
Remove default features from `image` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ web-sys = { version = "0.3.74", features = [
     "TouchEvent",
     "Window",
 ] }
-image = { version = "0.25.5", features = ["png"] } # For copying images
+image = { version = "0.25.5", default-features = false, features = ["png"] } # For copying images
 js-sys = "0.3.63"
 wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"


### PR DESCRIPTION
Import the `image` dependency without its default features, for consistency with `bevy_image` and to avoid the `avif` feature which pulls some NCSA license, which is currently not one of the licenses Bevy itself approves. This makes it more consistent with Bevy.

Fixes #379