### PR TITLE
Add shorthand for multipass plugin field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,24 @@ pub struct EguiPlugin {
     pub enable_multipass_for_primary_context: bool,
 }
 
+impl EguiPlugin {
+    /// Creates a new [`EguiPlugin`] with multipass disabled for the primary context. See
+    /// [`EguiPlugin::enable_multipass_for_primary_context`] for more details.
+    pub fn single_pass() -> Self {
+        Self {
+            enable_multipass_for_primary_context: false,
+        }
+    }
+
+    /// Creates a new [`EguiPlugin`] with multipass enabled for the primary context. See
+    /// [`EguiPlugin::enable_multipass_for_primary_context`] for more details.
+    pub fn multipass() -> Self {
+        Self {
+            enable_multipass_for_primary_context: true,
+        }
+    }
+}
+
 /// A resource for storing global plugin settings.
 #[derive(Clone, Debug, Resource, Reflect)]
 pub struct EguiGlobalSettings {


### PR DESCRIPTION
This is 100% an ergonomics issue, but `.add_plugins((DefaultPlugins, EguiPlugin))` used to fit on one line with no problems. Now adding only `EguiPlugin` will force a line wrap. I propose to add `EguiPlugin::single_pass()` and `EguiPlugin::multi_pass()` constructors to make this look nicer and reduce typing. `enable_multipass_for_primary_context` is quite long for a field name, so some sort of abstraction over it is warranted in my opinion.

### Open Question

Should `bevy_egui` also provide a default option? Many people will simply throw the type name into the plugin tuple like this:
```rs
.add_plugins((DefaultPlugins, EguiPlugin))
```
...and then see a compiler error. My go-to solution in this case is to slap a `::default()` on the end of the offending plugin. In the case of `bevy_egui`, this doesn't work.

Off the top, since multi-pass is experimental at the moment, I'd turn it off by default, but there's definitely an argument for not providing a default since it's likely to change in the near future.

This is orthogonal to the multipass shorthand, though, so it shouldn't block.