### PR TITLE
Deprecate the option to disable the multi-pass mode

### DIFF
--- a/examples/absorb_input.rs
+++ b/examples/absorb_input.rs
@@ -15,9 +15,7 @@ use bevy_egui::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(Startup, setup_scene_system)
         .add_systems(EguiContextPass, ui_system)
         // You can wrap your systems with the `egui_wants_any_pointer_input`, `egui_wants_any_keyboard_input` run conditions if you

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -18,9 +18,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::WHITE))
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .init_resource::<AppState>()
         .add_systems(Startup, setup_system)
         .add_systems(

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -4,9 +4,7 @@ use bevy_egui::{EguiContextPass, EguiPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(EguiContextPass, foo::ui_system)
         .run();
 }

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -22,13 +22,7 @@ use wgpu_types::{Extent3d, TextureUsages};
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            EguiPlugin {
-                enable_multipass_for_primary_context: true,
-            },
-            CustomPipelinePlugin,
-        ))
+        .add_plugins((DefaultPlugins, EguiPlugin::default(), CustomPipelinePlugin))
         .add_systems(Startup, setup_worldspace)
         .add_systems(EguiContextPass, ui_example_system)
         .add_systems(WorldspaceContextPass, ui_render_to_image_example_system)

--- a/examples/render_egui_to_image.rs
+++ b/examples/render_egui_to_image.rs
@@ -10,9 +10,7 @@ use wgpu_types::{Extent3d, TextureUsages};
 fn main() {
     let mut app = App::new();
     app.add_plugins((DefaultPlugins, MeshPickingPlugin));
-    app.add_plugins(EguiPlugin {
-        enable_multipass_for_primary_context: true,
-    });
+    app.add_plugins(EguiPlugin::default());
     app.add_systems(Startup, setup_worldspace_system);
     app.add_systems(Update, draw_gizmos_system);
     app.add_systems(EguiContextPass, update_screenspace_system);

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -13,9 +13,7 @@ use bevy_egui::{egui::Widget, EguiContextPass, EguiContexts, EguiPlugin, EguiUse
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(
             EguiContextPass,

--- a/examples/run_manually.rs
+++ b/examples/run_manually.rs
@@ -7,9 +7,7 @@ use std::num::NonZero;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: false,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(
             PreStartup,
             configure_context.after(EguiStartupSet::InitContexts),

--- a/examples/side_panel_2d.rs
+++ b/examples/side_panel_2d.rs
@@ -5,9 +5,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::srgb(0.25, 0.25, 0.25)))
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(Startup, setup_system)
         .add_systems(EguiContextPass, ui_example_system)
         .run();

--- a/examples/side_panel_3d.rs
+++ b/examples/side_panel_3d.rs
@@ -18,9 +18,7 @@ fn main() {
     App::new()
         .insert_resource(WinitSettings::desktop_app())
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .init_resource::<OccupiedScreenSpace>()
         .add_systems(Startup, setup_system)
         .add_systems(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,9 +4,7 @@ use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         // Systems that create Egui widgets should be run during the `CoreSet::Update` set,
         // or after the `EguiPreUpdateSet::BeginPass` system (which belongs to the `CoreSet::PreUpdate` set).
         .add_systems(EguiContextPass, ui_example_system)

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -19,9 +19,7 @@ pub struct SecondWindowContextPass;
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .init_resource::<SharedUiState>()
         .add_systems(Startup, load_assets_system)
         .add_systems(Startup, create_new_window_system)

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -43,9 +43,7 @@ fn main() {
                     ..default()
                 }),
         )
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_systems(Startup, configure_visuals_system)
         .add_systems(Startup, configure_ui_state_system)
         .add_systems(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,19 @@ pub struct EguiPlugin {
     ///     // ...
     /// }
     /// ```
+    #[deprecated(
+        note = "The option to disable the multi-pass mode is now deprecated, use `EguiPlugin::default` instead"
+    )]
     pub enable_multipass_for_primary_context: bool,
+}
+
+impl Default for EguiPlugin {
+    fn default() -> Self {
+        Self {
+            #[allow(deprecated)]
+            enable_multipass_for_primary_context: true,
+        }
+    }
 }
 
 /// A resource for storing global plugin settings.
@@ -970,6 +982,7 @@ impl Plugin for EguiPlugin {
         app.add_event::<EguiInputEvent>();
         app.add_event::<EguiFileDragAndDropEvent>();
 
+        #[allow(deprecated)]
         if self.enable_multipass_for_primary_context {
             app.insert_resource(EnableMultipassForPrimaryContext);
         }


### PR DESCRIPTION
This PR deprecates the option to disable the multi-pass mode. Ideally, that's the only mode I'd like to support in `bevy_egui`, as it helps to keep systems organised in a single schedule (`EguiContextPass`), which in turn helps to avoid issues such as #212, makes widgets requiring multiple passes work by default (#358), etc.

Also, I hope that the deprecation will prompt users to report issues with the multi-pass mode if there are any. If there are issues with the multi-pass mode that can't be easily solved or there are any reasons why users want to keep using the single-pass mode (or, for example the `Update` schedule specifically), we'll at least learn of those. (And there's always an option to "un-deprecate" the single-pass mode in that case.)

Having said that, my intention is to keep the single-pass mode support around for Bevy 0.16-0.17, and I hope to remove it completely with Bevy 0.18.